### PR TITLE
feat: calcul automatique des TeamStat après validation (#33)

### DIFF
--- a/src/Controller/DivisionController.php
+++ b/src/Controller/DivisionController.php
@@ -9,6 +9,7 @@ use App\Repository\TeamRepository;
 use App\Repository\SeasonRepository;
 use App\Repository\GameStatusRepository;
 use App\Service\PushNotificationService;
+use App\Service\TeamStatCalculatorService;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Attribute\Route;
@@ -596,6 +597,21 @@ class DivisionController extends BaseController
     /**
      * Génère les matchs retour pour un Double Round Robin
      */
+    /**
+     * POST /api/divisions/{id}/recalculate-stats - Recalcul complet des stats d'une division (admin)
+     */
+    #[Route('/divisions/{id}/recalculate-stats', name: 'api_division_recalculate_stats', methods: ['POST'], requirements: ['id' => '\d+'])]
+    public function recalculateStats(int $id, TeamStatCalculatorService $statCalculator): JsonResponse
+    {
+        $this->checkUserRole('ROLE_ADMIN');
+
+        $division = $this->findEntityOrFail('App\Entity\Division', $id, 'Division');
+
+        $statCalculator->recalculateDivisionStats($division);
+
+        return $this->json(['message' => 'Stats recalculated successfully']);
+    }
+
     private function generateReturnSchedule(array $schedule): array
     {
         $returnSchedule = [];

--- a/src/Controller/MatchResultController.php
+++ b/src/Controller/MatchResultController.php
@@ -7,6 +7,7 @@ use App\Entity\MatchResult;
 use App\Exception\ApiProblemException;
 use App\Repository\MatchResultRepository;
 use App\Service\PushNotificationService;
+use App\Service\TeamStatCalculatorService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -129,6 +130,7 @@ class MatchResultController extends BaseController
         int $id,
         int $resultId,
         PushNotificationService $pushNotificationService,
+        TeamStatCalculatorService $statCalculator,
     ): JsonResponse {
         $user = $this->getAuthenticatedUser();
 
@@ -176,6 +178,12 @@ class MatchResultController extends BaseController
         $this->entityManager->persist($result);
         $this->entityManager->persist($game);
         $this->entityManager->flush();
+
+        try {
+            $statCalculator->updateStatsAfterGame($game);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to update team stats', ['error' => $e->getMessage()]);
+        }
 
         // Notifier le soumetteur que le resultat a ete valide
         $submitter = $result->getSubmittedBy();
@@ -281,6 +289,7 @@ class MatchResultController extends BaseController
         int $id,
         int $resultId,
         Request $request,
+        TeamStatCalculatorService $statCalculator,
     ): JsonResponse {
         $this->checkUserRole('ROLE_ADMIN');
 
@@ -317,6 +326,12 @@ class MatchResultController extends BaseController
         $this->entityManager->persist($result);
         $this->entityManager->persist($game);
         $this->entityManager->flush();
+
+        try {
+            $statCalculator->updateStatsAfterGame($game);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to update team stats', ['error' => $e->getMessage()]);
+        }
 
         return $this->json($this->formatEntityData($result));
     }

--- a/src/Repository/GameRepository.php
+++ b/src/Repository/GameRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repository;
 
+use App\Entity\Division;
 use App\Entity\Game;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -29,6 +30,21 @@ class GameRepository extends ServiceEntityRepository
             ->andWhere('g.reminderSentAt IS NULL')
             ->setParameter('from', $from)
             ->setParameter('to', $to)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @return Game[]
+     */
+    public function findPlayedByDivision(Division $division): array
+    {
+        return $this->createQueryBuilder('g')
+            ->join('g.status', 's')
+            ->where('g.division = :division')
+            ->andWhere('s.name = :status')
+            ->setParameter('division', $division)
+            ->setParameter('status', 'played')
             ->getQuery()
             ->getResult();
     }

--- a/src/Repository/TeamStatRepository.php
+++ b/src/Repository/TeamStatRepository.php
@@ -26,6 +26,14 @@ class TeamStatRepository extends ServiceEntityRepository
         ]);
     }
 
+    /**
+     * @return TeamStat[]
+     */
+    public function findByDivision(Division $division): array
+    {
+        return $this->findBy(['division' => $division]);
+    }
+
     //    /**
     //     * @return TeamStat[] Returns an array of TeamStat objects
     //     */

--- a/src/Security/SecuredControllerTrait.php
+++ b/src/Security/SecuredControllerTrait.php
@@ -3,6 +3,7 @@
 namespace App\Security;
 
 use App\Entity\User;
+use App\Exception\ApiProblemException;
 use App\Service\AuthenticationService;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
@@ -41,7 +42,7 @@ trait SecuredControllerTrait
         }
 
         if (!$this->authService->userHasRole($user, $role)) {
-            throw new AccessDeniedException("Role $role required");
+            throw ApiProblemException::forbidden("Role $role required");
         }
     }
 

--- a/src/Service/TeamStatCalculatorService.php
+++ b/src/Service/TeamStatCalculatorService.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Division;
+use App\Entity\Game;
+use App\Entity\TeamStat;
+use App\Repository\GameRepository;
+use App\Repository\TeamStatRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+class TeamStatCalculatorService
+{
+    private const POINTS_WIN = 3;
+    private const POINTS_LOSS = 0;
+
+    public function __construct(
+        private readonly TeamStatRepository $teamStatRepository,
+        private readonly GameRepository $gameRepository,
+        private readonly EntityManagerInterface $entityManager,
+    ) {}
+
+    public function updateStatsAfterGame(Game $game): void
+    {
+        $team1 = $game->getTeam1();
+        $team2 = $game->getTeam2();
+        $division = $game->getDivision();
+
+        if (!$team1 || !$team2 || !$division) {
+            return;
+        }
+
+        $stat1 = $this->getOrCreateStat($team1, $division);
+        $stat2 = $this->getOrCreateStat($team2, $division);
+
+        $score1 = $game->getScore1() ?? 0;
+        $score2 = $game->getScore2() ?? 0;
+        $winner = $game->getWinner();
+
+        $stat1->setWinRounds($stat1->getWinRounds() + $score1);
+        $stat1->setLooseRounds($stat1->getLooseRounds() + $score2);
+
+        $stat2->setWinRounds($stat2->getWinRounds() + $score2);
+        $stat2->setLooseRounds($stat2->getLooseRounds() + $score1);
+
+        if ($winner === 1) {
+            $stat1->setWins($stat1->getWins() + 1);
+            $stat1->setPoints($stat1->getPoints() + self::POINTS_WIN);
+            $stat2->setLosses($stat2->getLosses() + 1);
+            $stat2->setPoints($stat2->getPoints() + self::POINTS_LOSS);
+        } elseif ($winner === 2) {
+            $stat2->setWins($stat2->getWins() + 1);
+            $stat2->setPoints($stat2->getPoints() + self::POINTS_WIN);
+            $stat1->setLosses($stat1->getLosses() + 1);
+            $stat1->setPoints($stat1->getPoints() + self::POINTS_LOSS);
+        }
+
+        $this->entityManager->flush();
+    }
+
+    public function recalculateDivisionStats(Division $division): void
+    {
+        $existingStats = $this->teamStatRepository->findByDivision($division);
+        foreach ($existingStats as $stat) {
+            $stat->setWins(0);
+            $stat->setLosses(0);
+            $stat->setTies(0);
+            $stat->setPoints(0);
+            $stat->setWinRounds(0);
+            $stat->setLooseRounds(0);
+        }
+
+        $games = $this->gameRepository->findPlayedByDivision($division);
+        foreach ($games as $game) {
+            $this->applyGameToStats($game, $existingStats);
+        }
+
+        $this->entityManager->flush();
+    }
+
+    private function getOrCreateStat($team, Division $division): TeamStat
+    {
+        $stat = $this->teamStatRepository->findByTeamAndDivision($team, $division);
+
+        if ($stat === null) {
+            $stat = new TeamStat();
+            $stat->setTeam($team);
+            $stat->setDivision($division);
+            $stat->setWins(0);
+            $stat->setLosses(0);
+            $stat->setTies(0);
+            $stat->setPoints(0);
+            $stat->setWinRounds(0);
+            $stat->setLooseRounds(0);
+            $this->entityManager->persist($stat);
+        }
+
+        return $stat;
+    }
+
+    /**
+     * @param TeamStat[] $statsIndex
+     */
+    private function applyGameToStats(Game $game, array $statsIndex): void
+    {
+        $team1 = $game->getTeam1();
+        $team2 = $game->getTeam2();
+
+        if (!$team1 || !$team2) {
+            return;
+        }
+
+        $stat1 = $this->findStatForTeam($statsIndex, $team1);
+        $stat2 = $this->findStatForTeam($statsIndex, $team2);
+
+        if (!$stat1 || !$stat2) {
+            return;
+        }
+
+        $score1 = $game->getScore1() ?? 0;
+        $score2 = $game->getScore2() ?? 0;
+        $winner = $game->getWinner();
+
+        $stat1->setWinRounds($stat1->getWinRounds() + $score1);
+        $stat1->setLooseRounds($stat1->getLooseRounds() + $score2);
+
+        $stat2->setWinRounds($stat2->getWinRounds() + $score2);
+        $stat2->setLooseRounds($stat2->getLooseRounds() + $score1);
+
+        if ($winner === 1) {
+            $stat1->setWins($stat1->getWins() + 1);
+            $stat1->setPoints($stat1->getPoints() + self::POINTS_WIN);
+            $stat2->setLosses($stat2->getLosses() + 1);
+        } elseif ($winner === 2) {
+            $stat2->setWins($stat2->getWins() + 1);
+            $stat2->setPoints($stat2->getPoints() + self::POINTS_WIN);
+            $stat1->setLosses($stat1->getLosses() + 1);
+        }
+    }
+
+    /**
+     * @param TeamStat[] $stats
+     */
+    private function findStatForTeam(array $stats, $team): ?TeamStat
+    {
+        foreach ($stats as $stat) {
+            if ($stat->getTeam() === $team) {
+                return $stat;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Functional/Controller/MatchResultControllerTest.php
+++ b/tests/Functional/Controller/MatchResultControllerTest.php
@@ -9,6 +9,7 @@ use App\Entity\MatchResult;
 use App\Entity\Season;
 use App\Entity\Team;
 use App\Entity\TeamMember;
+use App\Entity\TeamStat;
 use App\Entity\User;
 use App\Tests\Functional\ApiTestCase;
 
@@ -387,5 +388,122 @@ class MatchResultControllerTest extends ApiTestCase
         $this->assertArrayHasKey('status', $response[0]);
         $this->assertArrayHasKey('contest_reason', $response[0]);
         $this->assertArrayHasKey('created_at', $response[0]);
+    }
+
+    // ========================================================================
+    // Automatic TeamStat update after result validation
+    // ========================================================================
+
+    private function createMatchContextWithStats(): array
+    {
+        $ctx = $this->createMatchContext();
+
+        $stat1 = new TeamStat();
+        $stat1->setTeam($ctx['team1']);
+        $stat1->setDivision($ctx['game']->getDivision());
+        $stat1->setWins(0);
+        $stat1->setLosses(0);
+        $stat1->setTies(0);
+        $stat1->setPoints(0);
+        $stat1->setWinRounds(0);
+        $stat1->setLooseRounds(0);
+        $this->entityManager->persist($stat1);
+
+        $stat2 = new TeamStat();
+        $stat2->setTeam($ctx['team2']);
+        $stat2->setDivision($ctx['game']->getDivision());
+        $stat2->setWins(0);
+        $stat2->setLosses(0);
+        $stat2->setTies(0);
+        $stat2->setPoints(0);
+        $stat2->setWinRounds(0);
+        $stat2->setLooseRounds(0);
+        $this->entityManager->persist($stat2);
+
+        $this->entityManager->flush();
+
+        return array_merge($ctx, ['stat1' => $stat1, 'stat2' => $stat2]);
+    }
+
+    public function testValidateResultUpdatesTeamStats(): void
+    {
+        $ctx = $this->createMatchContextWithStats();
+        $result = $this->createPendingResult($ctx);
+
+        $this->client->loginUser($ctx['captain2'], 'api');
+        $this->jsonRequest('PATCH', '/api/games/' . $ctx['game']->getId() . '/results/' . $result->getId() . '/validate');
+
+        $this->assertResponseStatusCode(200);
+
+        $this->entityManager->clear();
+
+        $stat1 = $this->entityManager->find(TeamStat::class, $ctx['stat1']->getId());
+        $stat2 = $this->entityManager->find(TeamStat::class, $ctx['stat2']->getId());
+
+        // captain1 a soumis score 3-1, team1 gagne
+        $this->assertEquals(1, $stat1->getWins());
+        $this->assertEquals(0, $stat1->getLosses());
+        $this->assertEquals(3, $stat1->getPoints());
+        $this->assertEquals(3, $stat1->getWinRounds());
+        $this->assertEquals(1, $stat1->getLooseRounds());
+
+        $this->assertEquals(0, $stat2->getWins());
+        $this->assertEquals(1, $stat2->getLosses());
+        $this->assertEquals(0, $stat2->getPoints());
+        $this->assertEquals(1, $stat2->getWinRounds());
+        $this->assertEquals(3, $stat2->getLooseRounds());
+    }
+
+    public function testAdminValidateResultUpdatesTeamStats(): void
+    {
+        $ctx = $this->createMatchContextWithStats();
+        $result = $this->createPendingResult($ctx);
+
+        $this->client->loginUser($ctx['admin'], 'api');
+        $this->jsonRequest('PATCH', '/api/games/' . $ctx['game']->getId() . '/results/' . $result->getId() . '/admin-validate', [
+            'score1' => 1,
+            'score2' => 3,
+        ]);
+
+        $this->assertResponseStatusCode(200);
+
+        $this->entityManager->clear();
+
+        $stat1 = $this->entityManager->find(TeamStat::class, $ctx['stat1']->getId());
+        $stat2 = $this->entityManager->find(TeamStat::class, $ctx['stat2']->getId());
+
+        // admin a corrigé le score à 1-3, team2 gagne
+        $this->assertEquals(0, $stat1->getWins());
+        $this->assertEquals(1, $stat1->getLosses());
+        $this->assertEquals(0, $stat1->getPoints());
+
+        $this->assertEquals(1, $stat2->getWins());
+        $this->assertEquals(0, $stat2->getLosses());
+        $this->assertEquals(3, $stat2->getPoints());
+    }
+
+    public function testValidateResultCreatesTeamStatIfMissing(): void
+    {
+        $ctx = $this->createMatchContext();
+        $result = $this->createPendingResult($ctx);
+
+        // Aucune TeamStat n'existe → le service doit en créer
+        $this->client->loginUser($ctx['captain2'], 'api');
+        $this->jsonRequest('PATCH', '/api/games/' . $ctx['game']->getId() . '/results/' . $result->getId() . '/validate');
+
+        $this->assertResponseStatusCode(200);
+
+        $this->entityManager->clear();
+
+        $division = $ctx['game']->getDivision();
+
+        $statRepo = $this->entityManager->getRepository(TeamStat::class);
+        $stat1 = $statRepo->findOneBy(['team' => $ctx['team1'], 'division' => $division]);
+        $stat2 = $statRepo->findOneBy(['team' => $ctx['team2'], 'division' => $division]);
+
+        $this->assertNotNull($stat1);
+        $this->assertNotNull($stat2);
+        $this->assertEquals(1, $stat1->getWins());
+        $this->assertEquals(1, $stat2->getLosses());
     }
 }

--- a/tests/Functional/Controller/TeamStatRecalculateControllerTest.php
+++ b/tests/Functional/Controller/TeamStatRecalculateControllerTest.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\Division;
+use App\Entity\Game;
+use App\Entity\GameStatus;
+use App\Entity\Season;
+use App\Entity\Team;
+use App\Entity\TeamMember;
+use App\Entity\TeamStat;
+use App\Entity\User;
+use App\Tests\Functional\ApiTestCase;
+
+class TeamStatRecalculateControllerTest extends ApiTestCase
+{
+    private function createDivisionContext(): array
+    {
+        $season = new Season();
+        $season->setName('Season Recap');
+        $season->setStartDate(new \DateTime('2024-01-01'));
+        $season->setEndDate(new \DateTime('2024-12-31'));
+        $this->entityManager->persist($season);
+
+        $division = new Division();
+        $division->setName('Division Recap');
+        $division->setSeason($season);
+        $this->entityManager->persist($division);
+
+        $playedStatus = new GameStatus();
+        $playedStatus->setName('played');
+        $this->entityManager->persist($playedStatus);
+
+        $team1 = new Team();
+        $team1->setName('Team Alpha');
+        $this->entityManager->persist($team1);
+
+        $team2 = new Team();
+        $team2->setName('Team Beta');
+        $this->entityManager->persist($team2);
+
+        $admin = new User();
+        $admin->setUsername('admin');
+        $admin->setPassword('hashed');
+        $admin->setRoles(['ROLE_USER', 'ROLE_ADMIN', 'ROLE_API']);
+        $admin->setIsActive(true);
+        $this->entityManager->persist($admin);
+
+        $regularUser = new User();
+        $regularUser->setUsername('regular');
+        $regularUser->setPassword('hashed');
+        $regularUser->setRoles(['ROLE_USER', 'ROLE_API']);
+        $regularUser->setIsActive(true);
+        $this->entityManager->persist($regularUser);
+
+        // Captain pour team1 (pour avoir setIsForfeit accessible)
+        $captain1 = new User();
+        $captain1->setUsername('cap1');
+        $captain1->setPassword('hashed');
+        $captain1->setRoles(['ROLE_USER', 'ROLE_API']);
+        $captain1->setIsActive(true);
+        $this->entityManager->persist($captain1);
+
+        $member1 = new TeamMember();
+        $member1->setRole(TeamMember::ROLE_CAPTAIN);
+        $member1->setJoinedAt(new \DateTimeImmutable());
+        $member1->setUser($captain1);
+        $team1->addMember($member1);
+        $team1->setCaptainUser($captain1);
+        $this->entityManager->persist($member1);
+
+        // Un match joué
+        $game = new Game();
+        $game->setDivision($division);
+        $game->setTeam1($team1);
+        $game->setTeam2($team2);
+        $game->setScore1(3);
+        $game->setScore2(1);
+        $game->setWinner(1);
+        $game->setWeek(1);
+        $game->setStatus($playedStatus);
+        $this->entityManager->persist($game);
+
+        // Stats intentionnellement fausses
+        $stat1 = new TeamStat();
+        $stat1->setTeam($team1);
+        $stat1->setDivision($division);
+        $stat1->setWins(99);
+        $stat1->setLosses(99);
+        $stat1->setTies(0);
+        $stat1->setPoints(99);
+        $stat1->setWinRounds(99);
+        $stat1->setLooseRounds(99);
+        $this->entityManager->persist($stat1);
+
+        $stat2 = new TeamStat();
+        $stat2->setTeam($team2);
+        $stat2->setDivision($division);
+        $stat2->setWins(99);
+        $stat2->setLosses(99);
+        $stat2->setTies(0);
+        $stat2->setPoints(99);
+        $stat2->setWinRounds(99);
+        $stat2->setLooseRounds(99);
+        $this->entityManager->persist($stat2);
+
+        $this->entityManager->flush();
+
+        return [
+            'division' => $division,
+            'team1' => $team1,
+            'team2' => $team2,
+            'game' => $game,
+            'stat1' => $stat1,
+            'stat2' => $stat2,
+            'admin' => $admin,
+            'regularUser' => $regularUser,
+        ];
+    }
+
+    public function testAdminCanRecalculateDivisionStats(): void
+    {
+        $ctx = $this->createDivisionContext();
+
+        $this->client->loginUser($ctx['admin'], 'api');
+
+        $response = $this->jsonRequest('POST', '/api/divisions/' . $ctx['division']->getId() . '/recalculate-stats');
+
+        $this->assertResponseStatusCode(200);
+        $this->assertIsArray($response);
+        $this->assertArrayHasKey('message', $response);
+
+        $this->entityManager->clear();
+
+        $stat1 = $this->entityManager->find(TeamStat::class, $ctx['stat1']->getId());
+        $stat2 = $this->entityManager->find(TeamStat::class, $ctx['stat2']->getId());
+
+        // Stats recalculées à partir du vrai jeu (3-1, team1 gagne)
+        $this->assertEquals(1, $stat1->getWins());
+        $this->assertEquals(0, $stat1->getLosses());
+        $this->assertEquals(3, $stat1->getPoints());
+        $this->assertEquals(3, $stat1->getWinRounds());
+        $this->assertEquals(1, $stat1->getLooseRounds());
+
+        $this->assertEquals(0, $stat2->getWins());
+        $this->assertEquals(1, $stat2->getLosses());
+        $this->assertEquals(0, $stat2->getPoints());
+        $this->assertEquals(1, $stat2->getWinRounds());
+        $this->assertEquals(3, $stat2->getLooseRounds());
+    }
+
+    public function testRecalculateRequiresAdmin(): void
+    {
+        $ctx = $this->createDivisionContext();
+
+        $this->client->loginUser($ctx['regularUser'], 'api');
+
+        $this->jsonRequest('POST', '/api/divisions/' . $ctx['division']->getId() . '/recalculate-stats');
+
+        $this->assertResponseStatusCode(403);
+    }
+
+    public function testRecalculateRequiresAuthentication(): void
+    {
+        $ctx = $this->createDivisionContext();
+
+        $this->jsonRequest('POST', '/api/divisions/' . $ctx['division']->getId() . '/recalculate-stats');
+
+        $statusCode = $this->client->getResponse()->getStatusCode();
+        $this->assertGreaterThanOrEqual(400, $statusCode);
+        $this->assertNotEquals(200, $statusCode);
+    }
+
+    public function testRecalculateUnknownDivisionReturns404(): void
+    {
+        $ctx = $this->createDivisionContext();
+
+        $this->client->loginUser($ctx['admin'], 'api');
+
+        $this->jsonRequest('POST', '/api/divisions/99999/recalculate-stats');
+
+        $this->assertResponseStatusCode(404);
+    }
+}

--- a/tests/Unit/Service/TeamStatCalculatorServiceTest.php
+++ b/tests/Unit/Service/TeamStatCalculatorServiceTest.php
@@ -1,0 +1,431 @@
+<?php
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\Division;
+use App\Entity\Game;
+use App\Entity\GameStatus;
+use App\Entity\Team;
+use App\Entity\TeamStat;
+use App\Repository\GameRepository;
+use App\Repository\TeamStatRepository;
+use App\Service\TeamStatCalculatorService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class TeamStatCalculatorServiceTest extends TestCase
+{
+    private TeamStatRepository $teamStatRepository;
+    private GameRepository $gameRepository;
+    private EntityManagerInterface $entityManager;
+    private TeamStatCalculatorService $service;
+
+    protected function setUp(): void
+    {
+        $this->teamStatRepository = $this->createMock(TeamStatRepository::class);
+        $this->gameRepository = $this->createMock(GameRepository::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $this->service = new TeamStatCalculatorService(
+            $this->teamStatRepository,
+            $this->gameRepository,
+            $this->entityManager,
+        );
+    }
+
+    // =========================================================================
+    // updateStatsAfterGame — victoire team1
+    // =========================================================================
+
+    public function testTeam1WinIncreasesTeam1WinsAndDeductsLoserPoints(): void
+    {
+        $division = new Division();
+        $division->setName('Div A');
+
+        $team1 = new Team();
+        $team1->setName('Team Alpha');
+
+        $team2 = new Team();
+        $team2->setName('Team Beta');
+
+        $game = $this->buildPlayedGame($division, $team1, $team2, score1: 3, score2: 1, winner: 1);
+
+        $stat1 = $this->buildZeroStat($team1, $division);
+        $stat2 = $this->buildZeroStat($team2, $division);
+
+        $this->teamStatRepository->method('findByTeamAndDivision')
+            ->willReturnMap([
+                [$team1, $division, $stat1],
+                [$team2, $division, $stat2],
+            ]);
+
+        $this->entityManager->expects($this->never())->method('persist');
+        $this->entityManager->expects($this->once())->method('flush');
+
+        $this->service->updateStatsAfterGame($game);
+
+        $this->assertEquals(1, $stat1->getWins());
+        $this->assertEquals(0, $stat1->getLosses());
+        $this->assertEquals(0, $stat1->getTies());
+        $this->assertEquals(3, $stat1->getPoints());
+
+        $this->assertEquals(0, $stat2->getWins());
+        $this->assertEquals(1, $stat2->getLosses());
+        $this->assertEquals(0, $stat2->getTies());
+        $this->assertEquals(0, $stat2->getPoints());
+    }
+
+    public function testTeam2WinIncreasesTeam2WinsAndPoints(): void
+    {
+        $division = new Division();
+        $division->setName('Div B');
+
+        $team1 = new Team();
+        $team1->setName('Team Alpha');
+
+        $team2 = new Team();
+        $team2->setName('Team Beta');
+
+        $game = $this->buildPlayedGame($division, $team1, $team2, score1: 1, score2: 3, winner: 2);
+
+        $stat1 = $this->buildZeroStat($team1, $division);
+        $stat2 = $this->buildZeroStat($team2, $division);
+
+        $this->teamStatRepository->method('findByTeamAndDivision')
+            ->willReturnMap([
+                [$team1, $division, $stat1],
+                [$team2, $division, $stat2],
+            ]);
+
+        $this->service->updateStatsAfterGame($game);
+
+        $this->assertEquals(0, $stat1->getWins());
+        $this->assertEquals(1, $stat1->getLosses());
+        $this->assertEquals(0, $stat1->getPoints());
+
+        $this->assertEquals(1, $stat2->getWins());
+        $this->assertEquals(0, $stat2->getLosses());
+        $this->assertEquals(3, $stat2->getPoints());
+    }
+
+    // =========================================================================
+    // updateStatsAfterGame — rounds gagnés/perdus
+    // =========================================================================
+
+    public function testWinRoundsAndLooseRoundsAreUpdatedCorrectly(): void
+    {
+        $division = new Division();
+        $division->setName('Div D');
+
+        $team1 = new Team();
+        $team1->setName('Team Alpha');
+
+        $team2 = new Team();
+        $team2->setName('Team Beta');
+
+        $game = $this->buildPlayedGame($division, $team1, $team2, score1: 3, score2: 1, winner: 1);
+
+        $stat1 = $this->buildZeroStat($team1, $division);
+        $stat2 = $this->buildZeroStat($team2, $division);
+
+        $this->teamStatRepository->method('findByTeamAndDivision')
+            ->willReturnMap([
+                [$team1, $division, $stat1],
+                [$team2, $division, $stat2],
+            ]);
+
+        $this->service->updateStatsAfterGame($game);
+
+        // team1 a gagné 3 rounds, perdu 1
+        $this->assertEquals(3, $stat1->getWinRounds());
+        $this->assertEquals(1, $stat1->getLooseRounds());
+
+        // team2 a gagné 1 round, perdu 3
+        $this->assertEquals(1, $stat2->getWinRounds());
+        $this->assertEquals(3, $stat2->getLooseRounds());
+    }
+
+    public function testRoundsAccumulateOverMultipleCalls(): void
+    {
+        $division = new Division();
+        $division->setName('Div E');
+
+        $team1 = new Team();
+        $team1->setName('Team Alpha');
+
+        $team2 = new Team();
+        $team2->setName('Team Beta');
+
+        $game1 = $this->buildPlayedGame($division, $team1, $team2, score1: 3, score2: 1, winner: 1);
+        $game2 = $this->buildPlayedGame($division, $team1, $team2, score1: 1, score2: 3, winner: 2);
+
+        $stat1 = $this->buildZeroStat($team1, $division);
+        $stat2 = $this->buildZeroStat($team2, $division);
+
+        $this->teamStatRepository->method('findByTeamAndDivision')
+            ->willReturnMap([
+                [$team1, $division, $stat1],
+                [$team2, $division, $stat2],
+            ]);
+
+        $this->service->updateStatsAfterGame($game1);
+        $this->service->updateStatsAfterGame($game2);
+
+        // After 2 games: team1 → 3+1=4 winRounds, 1+3=4 looseRounds
+        $this->assertEquals(4, $stat1->getWinRounds());
+        $this->assertEquals(4, $stat1->getLooseRounds());
+
+        // After 2 games: team2 → 1+3=4 winRounds, 3+1=4 looseRounds
+        $this->assertEquals(4, $stat2->getWinRounds());
+        $this->assertEquals(4, $stat2->getLooseRounds());
+    }
+
+    // =========================================================================
+    // updateStatsAfterGame — forfait
+    // =========================================================================
+
+    public function testForfeitTeam1LosesTeam2Wins(): void
+    {
+        $division = new Division();
+        $division->setName('Div F');
+
+        $team1 = new Team();
+        $team1->setName('Team Alpha');
+
+        $team2 = new Team();
+        $team2->setName('Team Beta');
+
+        // team1 forfait → score 0-4, team2 wins
+        $game = $this->buildPlayedGame($division, $team1, $team2, score1: 0, score2: 4, winner: 2);
+        $game->setIsForfeit(true);
+        $game->setForfeitTeam(1);
+
+        $stat1 = $this->buildZeroStat($team1, $division);
+        $stat2 = $this->buildZeroStat($team2, $division);
+
+        $this->teamStatRepository->method('findByTeamAndDivision')
+            ->willReturnMap([
+                [$team1, $division, $stat1],
+                [$team2, $division, $stat2],
+            ]);
+
+        $this->service->updateStatsAfterGame($game);
+
+        $this->assertEquals(0, $stat1->getWins());
+        $this->assertEquals(1, $stat1->getLosses());
+        $this->assertEquals(0, $stat1->getPoints());
+
+        $this->assertEquals(1, $stat2->getWins());
+        $this->assertEquals(0, $stat2->getLosses());
+        $this->assertEquals(3, $stat2->getPoints());
+    }
+
+    public function testForfeitTeam2LosesTeam1Wins(): void
+    {
+        $division = new Division();
+        $division->setName('Div G');
+
+        $team1 = new Team();
+        $team1->setName('Team Alpha');
+
+        $team2 = new Team();
+        $team2->setName('Team Beta');
+
+        // team2 forfait → score 4-0, team1 wins
+        $game = $this->buildPlayedGame($division, $team1, $team2, score1: 4, score2: 0, winner: 1);
+        $game->setIsForfeit(true);
+        $game->setForfeitTeam(2);
+
+        $stat1 = $this->buildZeroStat($team1, $division);
+        $stat2 = $this->buildZeroStat($team2, $division);
+
+        $this->teamStatRepository->method('findByTeamAndDivision')
+            ->willReturnMap([
+                [$team1, $division, $stat1],
+                [$team2, $division, $stat2],
+            ]);
+
+        $this->service->updateStatsAfterGame($game);
+
+        $this->assertEquals(1, $stat1->getWins());
+        $this->assertEquals(0, $stat1->getLosses());
+        $this->assertEquals(3, $stat1->getPoints());
+
+        $this->assertEquals(0, $stat2->getWins());
+        $this->assertEquals(1, $stat2->getLosses());
+        $this->assertEquals(0, $stat2->getPoints());
+    }
+
+    // =========================================================================
+    // updateStatsAfterGame — création TeamStat manquante
+    // =========================================================================
+
+    public function testCreatesTeamStatWhenMissing(): void
+    {
+        $division = new Division();
+        $division->setName('Div H');
+
+        $team1 = new Team();
+        $team1->setName('Team Alpha');
+
+        $team2 = new Team();
+        $team2->setName('Team Beta');
+
+        $game = $this->buildPlayedGame($division, $team1, $team2, score1: 3, score2: 1, winner: 1);
+
+        // Pas de TeamStat existantes → le service doit en créer
+        $this->teamStatRepository->method('findByTeamAndDivision')
+            ->willReturn(null);
+
+        $persisted = [];
+        $this->entityManager->expects($this->exactly(2))
+            ->method('persist')
+            ->willReturnCallback(function ($entity) use (&$persisted) {
+                $persisted[] = $entity;
+            });
+
+        $this->service->updateStatsAfterGame($game);
+
+        $this->assertCount(2, $persisted);
+        $this->assertContainsOnlyInstancesOf(TeamStat::class, $persisted);
+    }
+
+    public function testUpdatesExistingTeamStatWithoutCreatingNew(): void
+    {
+        $division = new Division();
+        $division->setName('Div I');
+
+        $team1 = new Team();
+        $team1->setName('Team Alpha');
+
+        $team2 = new Team();
+        $team2->setName('Team Beta');
+
+        $game = $this->buildPlayedGame($division, $team1, $team2, score1: 3, score2: 1, winner: 1);
+
+        $stat1 = $this->buildZeroStat($team1, $division);
+        $stat2 = $this->buildZeroStat($team2, $division);
+
+        $this->teamStatRepository->method('findByTeamAndDivision')
+            ->willReturnMap([
+                [$team1, $division, $stat1],
+                [$team2, $division, $stat2],
+            ]);
+
+        // Stats existantes → persist jamais appelé (pas de nouvelles entités)
+        $this->entityManager->expects($this->never())->method('persist');
+
+        $this->service->updateStatsAfterGame($game);
+    }
+
+    // =========================================================================
+    // recalculateDivisionStats
+    // =========================================================================
+
+    public function testRecalculateDivisionStatsResetsAndRebuildsFromScratch(): void
+    {
+        $division = new Division();
+        $division->setName('Div Recap');
+
+        $team1 = new Team();
+        $team1->setName('Team Alpha');
+
+        $team2 = new Team();
+        $team2->setName('Team Beta');
+
+        // Stats existantes avec de vieilles données
+        $stat1 = $this->buildStat($team1, $division, wins: 5, losses: 2, ties: 1, points: 16, winRounds: 20, looseRounds: 8);
+        $stat2 = $this->buildStat($team2, $division, wins: 2, losses: 5, ties: 1, points: 7, winRounds: 8, looseRounds: 20);
+
+        $playedStatus = new GameStatus();
+        $playedStatus->setName('played');
+
+        $game1 = $this->buildPlayedGame($division, $team1, $team2, score1: 3, score2: 1, winner: 1);
+        $game2 = $this->buildPlayedGame($division, $team1, $team2, score1: 1, score2: 3, winner: 2);
+
+        $this->gameRepository->expects($this->once())
+            ->method('findPlayedByDivision')
+            ->with($division)
+            ->willReturn([$game1, $game2]);
+
+        $this->teamStatRepository->expects($this->once())
+            ->method('findByDivision')
+            ->with($division)
+            ->willReturn([$stat1, $stat2]);
+
+        $this->service->recalculateDivisionStats($division);
+
+        // Après recalcul : 1 victoire chacun, 1 défaite chacun
+        // game1: team1 gagne 3-1 → stat1.winRounds+=3, looseRounds+=1
+        // game2: team2 gagne 1-3 → stat1.winRounds+=1, looseRounds+=3
+        $this->assertEquals(1, $stat1->getWins());
+        $this->assertEquals(1, $stat1->getLosses());
+        $this->assertEquals(0, $stat1->getTies());
+        $this->assertEquals(3, $stat1->getPoints());
+        $this->assertEquals(4, $stat1->getWinRounds());
+        $this->assertEquals(4, $stat1->getLooseRounds());
+
+        $this->assertEquals(1, $stat2->getWins());
+        $this->assertEquals(1, $stat2->getLosses());
+        $this->assertEquals(0, $stat2->getTies());
+        $this->assertEquals(3, $stat2->getPoints());
+        $this->assertEquals(4, $stat2->getWinRounds());
+        $this->assertEquals(4, $stat2->getLooseRounds());
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private function buildPlayedGame(
+        Division $division,
+        Team $team1,
+        Team $team2,
+        int $score1,
+        int $score2,
+        ?int $winner,
+    ): Game {
+        $status = new GameStatus();
+        $status->setName('played');
+
+        $game = new Game();
+        $game->setDivision($division);
+        $game->setTeam1($team1);
+        $game->setTeam2($team2);
+        $game->setScore1($score1);
+        $game->setScore2($score2);
+        $game->setWinner($winner);
+        $game->setStatus($status);
+        $game->setWeek(1);
+
+        return $game;
+    }
+
+    private function buildZeroStat(Team $team, Division $division): TeamStat
+    {
+        return $this->buildStat($team, $division, 0, 0, 0, 0, 0, 0);
+    }
+
+    private function buildStat(
+        Team $team,
+        Division $division,
+        int $wins,
+        int $losses,
+        int $ties,
+        int $points,
+        int $winRounds,
+        int $looseRounds,
+    ): TeamStat {
+        $stat = new TeamStat();
+        $stat->setTeam($team);
+        $stat->setDivision($division);
+        $stat->setWins($wins);
+        $stat->setLosses($losses);
+        $stat->setTies($ties);
+        $stat->setPoints($points);
+        $stat->setWinRounds($winRounds);
+        $stat->setLooseRounds($looseRounds);
+
+        return $stat;
+    }
+}


### PR DESCRIPTION
## Summary

- Nouveau `TeamStatCalculatorService` avec `updateStatsAfterGame()` (appelé après chaque validation) et `recalculateDivisionStats()` (recalcul complet depuis zéro)
- Intégration automatique dans `MatchResultController` : `validateResult` et `adminValidateResult` déclenchent la mise à jour des stats
- Endpoint admin `POST /api/divisions/{id}/recalculate-stats` pour forcer un recalcul complet
- Les forfaits sont gérés via le `winner` déjà calculé par l'entité `Game`
- Fix collatéral : `checkUserRole()` retournait 500 au lieu de 403 pour les rôles insuffisants

## Règles de calcul

- Victoire = 3 pts, Défaite = 0 pt (pas d'égalité possible)
- `winRounds` / `looseRounds` = maps gagnées/perdues par l'équipe
- Création automatique de `TeamStat` si inexistante pour la paire équipe/division

## Test plan

- [x] 9 tests unitaires `TeamStatCalculatorServiceTest` (victoire team1, victoire team2, rounds, forfait, création/mise à jour)
- [x] 3 tests fonctionnels dans `MatchResultControllerTest` (validate → stats, admin-validate → stats, création auto)
- [x] 4 tests fonctionnels `TeamStatRecalculateControllerTest` (succès admin, 403 non-admin, 401 non-authentifié, 404 division inconnue)
- [x] Aucune régression sur la suite existante

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)