### PR TITLE
feat: auto-dispute GameResult après timeout configurable (#41)

### DIFF
--- a/.env
+++ b/.env
@@ -80,3 +80,7 @@ MATCH_RESULT_REMINDER_HOUR=20
 MATCH_RESULT_DEADLINE_DAY=thursday
 MATCH_RESULT_DEADLINE_HOUR=22
 ###< match result timeout ###
+
+###> game result auto-dispute ###
+SCORE_VALIDATION_TIMEOUT_DAYS=3
+###< game result auto-dispute ###

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -16,6 +16,7 @@ parameters:
     match_result.reminder_hour: '%env(int:MATCH_RESULT_REMINDER_HOUR)%'
     match_result.deadline_day: '%env(MATCH_RESULT_DEADLINE_DAY)%'
     match_result.deadline_hour: '%env(int:MATCH_RESULT_DEADLINE_HOUR)%'
+    score_validation.timeout_days: '%env(int:SCORE_VALIDATION_TIMEOUT_DAYS)%'
 
 services:
     # default configuration for services in *this* file
@@ -56,3 +57,7 @@ services:
             $matchResultReminderHour: '%match_result.reminder_hour%'
             $matchResultDeadlineDay: '%match_result.deadline_day%'
             $matchResultDeadlineHour: '%match_result.deadline_hour%'
+
+    App\MessageHandler\GameResultTimeoutHandler:
+        arguments:
+            $scoreValidationTimeoutDays: '%score_validation.timeout_days%'

--- a/src/Entity/GameResult.php
+++ b/src/Entity/GameResult.php
@@ -100,4 +100,11 @@ class GameResult
         $this->respondedAt = new \DateTimeImmutable();
         return $this;
     }
+
+    public function autoDispute(): static
+    {
+        $this->status = self::STATUS_DISPUTED;
+        $this->respondedAt = new \DateTimeImmutable();
+        return $this;
+    }
 }

--- a/src/Message/GameResultTimeoutMessage.php
+++ b/src/Message/GameResultTimeoutMessage.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace App\Message;
+
+class GameResultTimeoutMessage {}

--- a/src/MessageHandler/GameResultTimeoutHandler.php
+++ b/src/MessageHandler/GameResultTimeoutHandler.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Message\GameResultTimeoutMessage;
+use App\Repository\GameResultRepository;
+use App\Repository\UserRepository;
+use App\Service\PushNotificationService;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class GameResultTimeoutHandler
+{
+    public function __construct(
+        private GameResultRepository $gameResultRepository,
+        private UserRepository $userRepository,
+        private PushNotificationService $pushNotificationService,
+        private EntityManagerInterface $entityManager,
+        private LoggerInterface $logger,
+        private int $scoreValidationTimeoutDays,
+    ) {}
+
+    public function __invoke(GameResultTimeoutMessage $message): void
+    {
+        $expired = $this->gameResultRepository->findExpiredPending($this->scoreValidationTimeoutDays);
+
+        $this->logger->info('Game result auto-dispute check', ['expired_count' => count($expired)]);
+
+        if (empty($expired)) {
+            return;
+        }
+
+        foreach ($expired as $result) {
+            $result->autoDispute();
+            $this->entityManager->persist($result);
+        }
+
+        $this->entityManager->flush();
+
+        $admins = $this->userRepository->findByRole('ROLE_ADMIN');
+        if (empty($admins)) {
+            return;
+        }
+
+        $count = count($expired);
+        try {
+            $this->pushNotificationService->sendToUsers(
+                $admins,
+                'Résultats en litige automatique',
+                sprintf('%d résultat(s) non confirmé(s) après %d jours — intervention admin requise', $count, $this->scoreValidationTimeoutDays),
+                '/admin/matches',
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to send auto-dispute admin notification', [
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/src/Repository/GameResultRepository.php
+++ b/src/Repository/GameResultRepository.php
@@ -38,6 +38,22 @@ class GameResultRepository extends ServiceEntityRepository
         ]);
     }
 
+    /**
+     * @return GameResult[]
+     */
+    public function findExpiredPending(int $timeoutDays): array
+    {
+        $cutoff = new \DateTimeImmutable("-{$timeoutDays} days");
+
+        return $this->createQueryBuilder('gr')
+            ->where('gr.status = :status')
+            ->andWhere('gr.createdAt < :cutoff')
+            ->setParameter('status', GameResult::STATUS_PENDING_VALIDATION)
+            ->setParameter('cutoff', $cutoff)
+            ->getQuery()
+            ->getResult();
+    }
+
     public function findLatestByGame(Game $game): ?GameResult
     {
         return $this->createQueryBuilder('gr')

--- a/src/Scheduler/MatchReminderSchedule.php
+++ b/src/Scheduler/MatchReminderSchedule.php
@@ -2,6 +2,7 @@
 
 namespace App\Scheduler;
 
+use App\Message\GameResultTimeoutMessage;
 use App\Message\MatchReminderMessage;
 use App\Message\MatchResultTimeoutMessage;
 use Symfony\Component\Scheduler\Attribute\AsSchedule;
@@ -16,6 +17,7 @@ class MatchReminderSchedule implements ScheduleProviderInterface
     {
         return (new Schedule())
             ->add(RecurringMessage::cron('0 * * * *', new MatchReminderMessage()))
-            ->add(RecurringMessage::cron('0 * * * *', new MatchResultTimeoutMessage()));
+            ->add(RecurringMessage::cron('0 * * * *', new MatchResultTimeoutMessage()))
+            ->add(RecurringMessage::cron('0 * * * *', new GameResultTimeoutMessage()));
     }
 }


### PR DESCRIPTION
## Summary
- Job Symfony Scheduler (hourly) détecte les `GameResult` en `pending_validation` expirés et les passe en `disputed` automatiquement
- Notification push aux admins après auto-litige
- Variable d'environnement `SCORE_VALIDATION_TIMEOUT_DAYS` (défaut: 3 jours)

## Changements
- `GameResultTimeoutMessage` + `GameResultTimeoutHandler` — handler horaire avec cutoff `createdAt < now - N jours`
- `GameResultRepository::findExpiredPending(int $days)` — requête DQL par date
- `GameResult::autoDispute()` — passe en `disputed` sans User (litige système)
- `MatchReminderSchedule` — ajout du nouveau message au cron
- `services.yaml` + `.env` — paramètre `SCORE_VALIDATION_TIMEOUT_DAYS`

## Test Plan
- [ ] Vérifier que le scheduler déclenche bien `GameResultTimeoutHandler` toutes les heures
- [ ] Créer un `GameResult` avec `createdAt` antérieur à 3 jours → vérifier passage en `disputed`
- [ ] Vérifier notification push envoyée aux admins
- [ ] Tester avec `SCORE_VALIDATION_TIMEOUT_DAYS=1` pour validation rapide

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)