### PR TITLE
feat: automated season/division closure when all games played (#32)

### DIFF
--- a/migrations/Version20260513100000.php
+++ b/migrations/Version20260513100000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260513100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add season.is_finalized for automated season closure';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE season ADD COLUMN is_finalized BOOLEAN NOT NULL DEFAULT false
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE season DROP COLUMN is_finalized
+        SQL);
+    }
+}

--- a/src/Controller/DivisionController.php
+++ b/src/Controller/DivisionController.php
@@ -9,6 +9,7 @@ use App\Repository\TeamRepository;
 use App\Repository\SeasonRepository;
 use App\Repository\GameStatusRepository;
 use App\Service\PushNotificationService;
+use App\Service\SeasonClosureService;
 use App\Service\TeamStatCalculatorService;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -355,8 +356,8 @@ class DivisionController extends BaseController
     public function patchDivision(
         int $id,
         Request $request,
-        TeamStatRepository $teamStatRepository,
-        PushNotificationService $pushNotificationService,
+        GameRepository $gameRepository,
+        SeasonClosureService $seasonClosureService,
     ): JsonResponse {
         $division = $this->findEntityOrFail(
             "App\Entity\Division",
@@ -382,34 +383,16 @@ class DivisionController extends BaseController
             && !$division->isFinalized();
 
         if ($shouldNotify) {
+            if ($gameRepository->count(['division' => $division]) === 0 || $gameRepository->hasNonPlayedGameInDivision($division)) {
+                throw ApiProblemException::conflict('Cannot finalize division: some games are not yet played');
+            }
             $division->setIsFinalized(true);
         }
 
         $response = $this->securedUpdateEntity($division);
 
         if ($shouldNotify) {
-            $teamStats = $teamStatRepository->findBy(['division' => $division]);
-            $users = [];
-            foreach ($teamStats as $teamStat) {
-                foreach ($teamStat->getTeam()->getMembers() as $member) {
-                    if ($member->getUser() !== null) {
-                        $users[] = $member->getUser();
-                    }
-                }
-            }
-            try {
-                $pushNotificationService->sendToUsers(
-                    $users,
-                    'Résultats finaux — ' . $division->getName(),
-                    'Les résultats de la division ' . $division->getName() . ' sont disponibles',
-                    '/divisions/' . $division->getId(),
-                );
-            } catch (\Throwable $e) {
-                $this->logger->error('Failed to send push notifications for division finalization', [
-                    'division_id' => $division->getId(),
-                    'error' => $e->getMessage(),
-                ]);
-            }
+            $seasonClosureService->notifyDivisionFinalized($division);
         }
 
         return $response;

--- a/src/Controller/GameController.php
+++ b/src/Controller/GameController.php
@@ -3,6 +3,7 @@
 namespace App\Controller;
 
 use App\Exception\ApiProblemException;
+use App\Service\SeasonClosureService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Attribute\Route;
 use App\Entity\Game;
@@ -251,7 +252,7 @@ class GameController extends BaseController
     }
 
     #[Route('/games/{id}', name: 'app_game_patch', methods: ['PATCH'], requirements: ['id' => '\d+'])]
-    public function patchGame(int $id, Request $request): JsonResponse
+    public function patchGame(int $id, Request $request, SeasonClosureService $seasonClosureService): JsonResponse
     {
         $game = $this->findEntityOrFail('App\Entity\Game', $id, 'Game');
         $data = $this->getRequestData($request);
@@ -289,9 +290,25 @@ class GameController extends BaseController
             }
         }
 
+        $becomesPlayed = isset($data['status'])
+            && $game->getStatus()?->getName() !== 'played';
+
         $this->setGameRelations($game, $data);
 
-        return $this->securedUpdateEntity($game);
+        $response = $this->securedUpdateEntity($game);
+
+        if ($becomesPlayed && $game->getStatus()?->getName() === 'played') {
+            try {
+                $seasonClosureService->onGamePlayed($game);
+            } catch (\Throwable $e) {
+                $this->logger->error('Failed to check season closure after game patch', [
+                    'game_id' => $game->getId(),
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        return $response;
     }
 
     #[Route('/games/{id}', name: 'app_game_delete', methods: ['DELETE'], requirements: ['id' => '\d+'])]

--- a/src/Controller/GameResultController.php
+++ b/src/Controller/GameResultController.php
@@ -8,6 +8,7 @@ use App\Exception\ApiProblemException;
 use App\Repository\GameResultRepository;
 use App\Repository\GameStatusRepository;
 use App\Repository\TeamStatRepository;
+use App\Service\SeasonClosureService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -105,6 +106,7 @@ class GameResultController extends BaseController
         GameResultRepository $resultRepository,
         GameStatusRepository $gameStatusRepository,
         TeamStatRepository $teamStatRepository,
+        SeasonClosureService $seasonClosureService,
     ): JsonResponse {
         $user = $this->getAuthenticatedUser();
         $game = $this->findEntityOrFail('App\Entity\Game', $id, 'Game');
@@ -160,6 +162,15 @@ class GameResultController extends BaseController
         $this->entityManager->persist($game);
         $this->entityManager->flush();
 
+        try {
+            $seasonClosureService->onGamePlayed($game);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to check season closure after game confirmation', [
+                'game_id' => $game->getId(),
+                'error' => $e->getMessage(),
+            ]);
+        }
+
         return $this->json($this->formatEntityData($result));
     }
 
@@ -208,6 +219,7 @@ class GameResultController extends BaseController
         GameResultRepository $resultRepository,
         GameStatusRepository $gameStatusRepository,
         TeamStatRepository $teamStatRepository,
+        SeasonClosureService $seasonClosureService,
     ): JsonResponse {
         $this->checkUserRole('ROLE_ADMIN');
 
@@ -257,6 +269,15 @@ class GameResultController extends BaseController
         $this->entityManager->persist($result);
         $this->entityManager->persist($game);
         $this->entityManager->flush();
+
+        try {
+            $seasonClosureService->onGamePlayed($game);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to check season closure after admin game resolution', [
+                'game_id' => $game->getId(),
+                'error' => $e->getMessage(),
+            ]);
+        }
 
         return $this->json($this->formatEntityData($result));
     }

--- a/src/Controller/MatchResultController.php
+++ b/src/Controller/MatchResultController.php
@@ -7,6 +7,7 @@ use App\Entity\MatchResult;
 use App\Exception\ApiProblemException;
 use App\Repository\MatchResultRepository;
 use App\Service\PushNotificationService;
+use App\Service\SeasonClosureService;
 use App\Service\TeamStatCalculatorService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -131,6 +132,7 @@ class MatchResultController extends BaseController
         int $resultId,
         PushNotificationService $pushNotificationService,
         TeamStatCalculatorService $statCalculator,
+        SeasonClosureService $seasonClosureService,
     ): JsonResponse {
         $user = $this->getAuthenticatedUser();
 
@@ -183,6 +185,15 @@ class MatchResultController extends BaseController
             $statCalculator->updateStatsAfterGame($game);
         } catch (\Throwable $e) {
             $this->logger->error('Failed to update team stats', ['error' => $e->getMessage()]);
+        }
+
+        try {
+            $seasonClosureService->onGamePlayed($game);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to check season closure after game validation', [
+                'game_id' => $game->getId(),
+                'error' => $e->getMessage(),
+            ]);
         }
 
         // Notifier le soumetteur que le resultat a ete valide
@@ -290,6 +301,7 @@ class MatchResultController extends BaseController
         int $resultId,
         Request $request,
         TeamStatCalculatorService $statCalculator,
+        SeasonClosureService $seasonClosureService,
     ): JsonResponse {
         $this->checkUserRole('ROLE_ADMIN');
 
@@ -331,6 +343,15 @@ class MatchResultController extends BaseController
             $statCalculator->updateStatsAfterGame($game);
         } catch (\Throwable $e) {
             $this->logger->error('Failed to update team stats', ['error' => $e->getMessage()]);
+        }
+
+        try {
+            $seasonClosureService->onGamePlayed($game);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to check season closure after admin game validation', [
+                'game_id' => $game->getId(),
+                'error' => $e->getMessage(),
+            ]);
         }
 
         return $this->json($this->formatEntityData($result));

--- a/src/Controller/SeasonController.php
+++ b/src/Controller/SeasonController.php
@@ -29,7 +29,8 @@ class SeasonController extends BaseController
             'id' => $entity->getId(),
             'name' => $entity->getName(),
             'start_date' => $entity->getStartDate()->format('d-m-Y'),
-            'end_date' => $entity->getEndDate()->format('d-m-Y')
+            'end_date' => $entity->getEndDate()->format('d-m-Y'),
+            'is_finalized' => $entity->isFinalized(),
         ];
     }
     /**
@@ -39,7 +40,7 @@ class SeasonController extends BaseController
     {
         $totalGames = 0;
         $finishedGames = 0;
-        $finishedStatus = $gameStatusRepository->findOneBy(['name' => 'joué']);
+        $finishedStatus = $gameStatusRepository->findOneBy(['name' => 'played']);
         $divisions = $divisionRepository->findBy(['season' => $season]);
 
         foreach ($divisions as $division) {
@@ -70,7 +71,8 @@ class SeasonController extends BaseController
             'id' => $season->getId(),
             'name' => $season->getName(),
             'start_date' => $season->getStartDate()->format('d-m-Y'),
-            'end_date' => $season->getEndDate()->format('d-m-Y')
+            'end_date' => $season->getEndDate()->format('d-m-Y'),
+            'is_finalized' => $season->isFinalized(),
         ];
 
         // Si les repositories sont fournis, ajouter les statistiques

--- a/src/Entity/Season.php
+++ b/src/Entity/Season.php
@@ -25,6 +25,9 @@ class Season
     #[ORM\Column(type: Types::DATE_MUTABLE, nullable: true)]
     private ?\DateTimeInterface $endDate = null;
 
+    #[ORM\Column(type: 'boolean', options: ['default' => false])]
+    private bool $isFinalized = false;
+
     /**
      * @var Collection<int, Registration>
      */
@@ -103,6 +106,18 @@ class Season
                 $registration->setSeason(null);
             }
         }
+
+        return $this;
+    }
+
+    public function isFinalized(): bool
+    {
+        return $this->isFinalized;
+    }
+
+    public function setIsFinalized(bool $isFinalized): static
+    {
+        $this->isFinalized = $isFinalized;
 
         return $this;
     }

--- a/src/Repository/DivisionRepository.php
+++ b/src/Repository/DivisionRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\Division;
+use App\Entity\Season;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -16,28 +17,16 @@ class DivisionRepository extends ServiceEntityRepository
         parent::__construct($registry, Division::class);
     }
 
-    //    /**
-    //     * @return Division[] Returns an array of Division objects
-    //     */
-    //    public function findByExampleField($value): array
-    //    {
-    //        return $this->createQueryBuilder('d')
-    //            ->andWhere('d.exampleField = :val')
-    //            ->setParameter('val', $value)
-    //            ->orderBy('d.id', 'ASC')
-    //            ->setMaxResults(10)
-    //            ->getQuery()
-    //            ->getResult()
-    //        ;
-    //    }
+    public function hasNonFinalizedDivisionInSeason(Season $season): bool
+    {
+        $count = (int) $this->createQueryBuilder('d')
+            ->select('COUNT(d.id)')
+            ->where('d.season = :season')
+            ->andWhere('d.isFinalized = false')
+            ->setParameter('season', $season)
+            ->getQuery()
+            ->getSingleScalarResult();
 
-    //    public function findOneBySomeField($value): ?Division
-    //    {
-    //        return $this->createQueryBuilder('d')
-    //            ->andWhere('d.exampleField = :val')
-    //            ->setParameter('val', $value)
-    //            ->getQuery()
-    //            ->getOneOrNullResult()
-    //        ;
-    //    }
+        return $count > 0;
+    }
 }

--- a/src/Repository/GameRepository.php
+++ b/src/Repository/GameRepository.php
@@ -48,4 +48,19 @@ class GameRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    public function hasNonPlayedGameInDivision(Division $division): bool
+    {
+        $count = (int) $this->createQueryBuilder('g')
+            ->select('COUNT(g.id)')
+            ->leftJoin('g.status', 's')
+            ->where('g.division = :division')
+            ->andWhere('s.name != :status OR s.id IS NULL')
+            ->setParameter('division', $division)
+            ->setParameter('status', 'played')
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return $count > 0;
+    }
 }

--- a/src/Service/SeasonClosureService.php
+++ b/src/Service/SeasonClosureService.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Division;
+use App\Entity\Game;
+use App\Entity\Season;
+use App\Repository\DivisionRepository;
+use App\Repository\GameRepository;
+use App\Repository\TeamStatRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+
+class SeasonClosureService
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private GameRepository $gameRepository,
+        private DivisionRepository $divisionRepository,
+        private TeamStatRepository $teamStatRepository,
+        private PushNotificationService $pushNotificationService,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function onGamePlayed(Game $game): void
+    {
+        $division = $game->getDivision();
+        if ($division === null) {
+            return;
+        }
+
+        $this->tryFinalizeDivision($division);
+    }
+
+    private function tryFinalizeDivision(Division $division): void
+    {
+        $this->entityManager->refresh($division);
+
+        if ($division->isFinalized()) {
+            return;
+        }
+
+        if ($this->gameRepository->count(['division' => $division]) === 0) {
+            return;
+        }
+
+        if ($this->gameRepository->hasNonPlayedGameInDivision($division)) {
+            return;
+        }
+
+        $division->setIsFinalized(true);
+        $this->entityManager->flush();
+
+        $this->notifyDivisionFinalized($division);
+
+        $season = $division->getSeason();
+        if ($season !== null) {
+            $this->tryFinalizeSeason($season);
+        }
+    }
+
+    private function tryFinalizeSeason(Season $season): void
+    {
+        $this->entityManager->refresh($season);
+
+        if ($season->isFinalized()) {
+            return;
+        }
+
+        if ($this->divisionRepository->hasNonFinalizedDivisionInSeason($season)) {
+            return;
+        }
+
+        $season->setIsFinalized(true);
+        $this->entityManager->flush();
+
+        $this->notifySeasonFinalized($season);
+    }
+
+    public function notifyDivisionFinalized(Division $division): void
+    {
+        $teamStats = $this->teamStatRepository->findBy(['division' => $division]);
+
+        $users = [];
+        foreach ($teamStats as $teamStat) {
+            foreach ($teamStat->getTeam()->getMembers() as $member) {
+                if ($member->getUser() !== null) {
+                    $users[] = $member->getUser();
+                }
+            }
+        }
+
+        if (empty($users)) {
+            return;
+        }
+
+        try {
+            $this->pushNotificationService->sendToUsers(
+                $users,
+                'Résultats finaux — ' . $division->getName(),
+                'Les résultats de la division ' . $division->getName() . ' sont disponibles',
+                '/divisions/' . $division->getId(),
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to send push notifications for division finalization', [
+                'division_id' => $division->getId(),
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    private function notifySeasonFinalized(Season $season): void
+    {
+        $divisions = $this->divisionRepository->findBy(['season' => $season]);
+
+        $users = [];
+        $seen = [];
+        foreach ($divisions as $division) {
+            $teamStats = $this->teamStatRepository->findBy(['division' => $division]);
+
+            foreach ($teamStats as $teamStat) {
+                foreach ($teamStat->getTeam()->getMembers() as $member) {
+                    $user = $member->getUser();
+                    if ($user !== null && !in_array($user->getId(), $seen, true)) {
+                        $seen[] = $user->getId();
+                        $users[] = $user;
+                    }
+                }
+            }
+        }
+
+        if (empty($users)) {
+            return;
+        }
+
+        try {
+            $this->pushNotificationService->sendToUsers(
+                $users,
+                'Saison terminée — ' . $season->getName(),
+                'La saison ' . $season->getName() . ' est maintenant clôturée',
+                '/seasons/' . $season->getId(),
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to send push notifications for season finalization', [
+                'season_id' => $season->getId(),
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/tests/Functional/Controller/SeasonClosureTest.php
+++ b/tests/Functional/Controller/SeasonClosureTest.php
@@ -1,0 +1,294 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\Division;
+use App\Entity\Game;
+use App\Entity\GameStatus;
+use App\Entity\Season;
+use App\Entity\Team;
+use App\Entity\TeamMember;
+use App\Entity\TeamStat;
+use App\Entity\User;
+use App\Service\SeasonClosureService;
+use App\Tests\Functional\ApiTestCase;
+
+class SeasonClosureTest extends ApiTestCase
+{
+    private function createBaseContext(int $gameCount = 1): array
+    {
+        $season = new Season();
+        $season->setName('Test Season');
+        $season->setStartDate(new \DateTime('2024-01-01'));
+        $season->setEndDate(new \DateTime('2024-12-31'));
+        $this->entityManager->persist($season);
+
+        $division = new Division();
+        $division->setName('Division A');
+        $division->setSeason($season);
+        $this->entityManager->persist($division);
+
+        $scheduledStatus = new GameStatus();
+        $scheduledStatus->setName('scheduled');
+        $this->entityManager->persist($scheduledStatus);
+
+        $playedStatus = new GameStatus();
+        $playedStatus->setName('played');
+        $this->entityManager->persist($playedStatus);
+
+        $pendingResultStatus = new GameStatus();
+        $pendingResultStatus->setName('pending_result');
+        $this->entityManager->persist($pendingResultStatus);
+
+        $team1 = new Team();
+        $team1->setName('Team Alpha');
+        $this->entityManager->persist($team1);
+
+        $team2 = new Team();
+        $team2->setName('Team Beta');
+        $this->entityManager->persist($team2);
+
+        $captain1 = new User();
+        $captain1->setUsername('captain1');
+        $captain1->setPassword('hashed');
+        $captain1->setRoles(['ROLE_USER', 'ROLE_API']);
+        $captain1->setIsActive(true);
+        $this->entityManager->persist($captain1);
+
+        $member1 = new TeamMember();
+        $member1->setRole(TeamMember::ROLE_CAPTAIN);
+        $member1->setJoinedAt(new \DateTimeImmutable());
+        $team1->addMember($member1);
+        $member1->setUser($captain1);
+        $team1->setCaptainUser($captain1);
+        $this->entityManager->persist($member1);
+
+        $captain2 = new User();
+        $captain2->setUsername('captain2');
+        $captain2->setPassword('hashed');
+        $captain2->setRoles(['ROLE_USER', 'ROLE_API']);
+        $captain2->setIsActive(true);
+        $this->entityManager->persist($captain2);
+
+        $member2 = new TeamMember();
+        $member2->setRole(TeamMember::ROLE_CAPTAIN);
+        $member2->setJoinedAt(new \DateTimeImmutable());
+        $team2->addMember($member2);
+        $member2->setUser($captain2);
+        $team2->setCaptainUser($captain2);
+        $this->entityManager->persist($member2);
+
+        $admin = new User();
+        $admin->setUsername('admin');
+        $admin->setPassword('hashed');
+        $admin->setRoles(['ROLE_USER', 'ROLE_ADMIN', 'ROLE_API']);
+        $admin->setIsActive(true);
+        $this->entityManager->persist($admin);
+
+        $stat1 = new TeamStat();
+        $stat1->setTeam($team1);
+        $stat1->setDivision($division);
+        $stat1->setWins(0)->setLosses(0)->setTies(0)->setPoints(0)->setWinRounds(0)->setLooseRounds(0);
+        $this->entityManager->persist($stat1);
+
+        $stat2 = new TeamStat();
+        $stat2->setTeam($team2);
+        $stat2->setDivision($division);
+        $stat2->setWins(0)->setLosses(0)->setTies(0)->setPoints(0)->setWinRounds(0)->setLooseRounds(0);
+        $this->entityManager->persist($stat2);
+
+        $games = [];
+        for ($i = 0; $i < $gameCount; $i++) {
+            $game = new Game();
+            $game->setTeam1($team1);
+            $game->setTeam2($team2);
+            $game->setStatus($scheduledStatus);
+            $game->setDivision($division);
+            $game->setWeek($i + 1);
+            $game->setScore1(0);
+            $game->setScore2(0);
+            $game->setDate(new \DateTime('+7 days'));
+            $this->entityManager->persist($game);
+            $games[] = $game;
+        }
+
+        $this->entityManager->flush();
+
+        return [
+            'season' => $season,
+            'division' => $division,
+            'team1' => $team1,
+            'team2' => $team2,
+            'captain1' => $captain1,
+            'captain2' => $captain2,
+            'admin' => $admin,
+            'games' => $games,
+            'game' => $games[0],
+            'playedStatus' => $playedStatus,
+            'scheduledStatus' => $scheduledStatus,
+        ];
+    }
+
+    private function getSeasonClosureService(): SeasonClosureService
+    {
+        return static::getContainer()->get(SeasonClosureService::class);
+    }
+
+    // ========================================================================
+    // Auto-finalisation de division
+    // ========================================================================
+
+    public function testDivisionAutoFinalizedWhenAllGamesPlayed(): void
+    {
+        $ctx = $this->createBaseContext(1);
+
+        $ctx['game']->setStatus($ctx['playedStatus']);
+        $this->entityManager->flush();
+
+        $this->getSeasonClosureService()->onGamePlayed($ctx['game']);
+
+        $this->entityManager->refresh($ctx['division']);
+        $this->assertTrue($ctx['division']->isFinalized());
+    }
+
+    public function testDivisionNotFinalizedWhenSomeGamesNotPlayed(): void
+    {
+        $ctx = $this->createBaseContext(2);
+
+        $ctx['games'][0]->setStatus($ctx['playedStatus']);
+        $this->entityManager->flush();
+
+        $this->getSeasonClosureService()->onGamePlayed($ctx['games'][0]);
+
+        $this->entityManager->refresh($ctx['division']);
+        $this->assertFalse($ctx['division']->isFinalized());
+    }
+
+    public function testDivisionNotFinalizedWhenGameReported(): void
+    {
+        $ctx = $this->createBaseContext(1);
+
+        $reportedStatus = new GameStatus();
+        $reportedStatus->setName('reported');
+        $this->entityManager->persist($reportedStatus);
+
+        $ctx['game']->setStatus($reportedStatus);
+        $this->entityManager->flush();
+
+        $this->getSeasonClosureService()->onGamePlayed($ctx['game']);
+
+        $this->entityManager->refresh($ctx['division']);
+        $this->assertFalse($ctx['division']->isFinalized());
+    }
+
+    public function testDivisionNotFinalizedTwice(): void
+    {
+        $ctx = $this->createBaseContext(1);
+
+        $ctx['game']->setStatus($ctx['playedStatus']);
+        $ctx['division']->setIsFinalized(true);
+        $this->entityManager->flush();
+
+        $service = $this->getSeasonClosureService();
+        $service->onGamePlayed($ctx['game']);
+
+        $this->entityManager->refresh($ctx['division']);
+        $this->assertTrue($ctx['division']->isFinalized());
+    }
+
+    // ========================================================================
+    // Auto-finalisation de saison
+    // ========================================================================
+
+    public function testSeasonAutoFinalizedWhenAllDivisionsFinalized(): void
+    {
+        $ctx = $this->createBaseContext(1);
+
+        $ctx['game']->setStatus($ctx['playedStatus']);
+        $this->entityManager->flush();
+
+        $this->getSeasonClosureService()->onGamePlayed($ctx['game']);
+
+        $this->entityManager->refresh($ctx['season']);
+        $this->assertTrue($ctx['season']->isFinalized());
+    }
+
+    public function testSeasonNotFinalizedWhenOneDivisionStillPending(): void
+    {
+        $ctx = $this->createBaseContext(1);
+
+        $division2 = new Division();
+        $division2->setName('Division B');
+        $division2->setSeason($ctx['season']);
+        $this->entityManager->persist($division2);
+
+        $game2 = new Game();
+        $game2->setTeam1($ctx['team1']);
+        $game2->setTeam2($ctx['team2']);
+        $game2->setStatus($ctx['scheduledStatus']);
+        $game2->setDivision($division2);
+        $game2->setWeek(1);
+        $game2->setScore1(0);
+        $game2->setScore2(0);
+        $game2->setDate(new \DateTime('+7 days'));
+        $this->entityManager->persist($game2);
+
+        $ctx['game']->setStatus($ctx['playedStatus']);
+        $this->entityManager->flush();
+
+        $this->getSeasonClosureService()->onGamePlayed($ctx['game']);
+
+        $this->entityManager->refresh($ctx['season']);
+        $this->assertFalse($ctx['season']->isFinalized());
+    }
+
+    // ========================================================================
+    // Validation préventive manuelle (DivisionController PATCH)
+    // ========================================================================
+
+    public function testManualFinalizationBlockedWhenGamesNotPlayed(): void
+    {
+        $ctx = $this->createBaseContext(1);
+
+        $this->client->loginUser($ctx['admin'], 'api');
+
+        $response = $this->jsonRequest('PATCH', '/api/divisions/' . $ctx['division']->getId(), [
+            'is_finalized' => true,
+        ]);
+
+        $this->assertResponseStatusCode(409);
+        $this->assertStringContainsString('Cannot finalize division', $response['detail']);
+    }
+
+    public function testManualFinalizationAllowedWhenAllGamesPlayed(): void
+    {
+        $ctx = $this->createBaseContext(1);
+
+        $ctx['game']->setStatus($ctx['playedStatus']);
+        $this->entityManager->flush();
+
+        $this->client->loginUser($ctx['admin'], 'api');
+
+        $response = $this->jsonRequest('PATCH', '/api/divisions/' . $ctx['division']->getId(), [
+            'is_finalized' => true,
+        ]);
+
+        $this->assertResponseStatusCode(200);
+        $this->assertTrue($response['is_finalized']);
+    }
+
+    // ========================================================================
+    // is_finalized exposé dans les réponses API
+    // ========================================================================
+
+    public function testSeasonResponseIncludesIsFinalized(): void
+    {
+        $ctx = $this->createBaseContext(1);
+
+        $response = $this->jsonRequest('GET', '/api/seasons/' . $ctx['season']->getId());
+
+        $this->assertResponseStatusCode(200);
+        $this->assertArrayHasKey('is_finalized', $response);
+        $this->assertFalse($response['is_finalized']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,16 @@
 
 use Symfony\Component\Dotenv\Dotenv;
 
-require dirname(__DIR__).'/vendor/autoload.php';
+$loader = require dirname(__DIR__).'/vendor/autoload.php';
+
+// In git worktrees, vendor/ is symlinked from the parent repo and its autoload
+// maps App\ to the parent src/. Override to use this worktree's src/.
+$worktreeDir = dirname(__DIR__);
+$vendorRealParent = dirname((string) realpath($worktreeDir . '/vendor'));
+if ($vendorRealParent !== $worktreeDir) {
+    $loader->setPsr4('App\\', [$worktreeDir . '/src', $worktreeDir . '/tests']);
+    $loader->register(true);
+}
 
 if (method_exists(Dotenv::class, 'bootEnv')) {
     (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');


### PR DESCRIPTION
## Summary

- Division auto-finalizes when all its games reach `played` status (triggered automatically, no API call needed)
- Season auto-finalizes when all its divisions are finalized, with push notifications to all team members
- Manual finalization via `PATCH /api/divisions/{id}` blocked (409) if any game is still pending

## Changes

- **New** `SeasonClosureService` — `onGamePlayed()` entry point called after every game validation
- **Triggers** added in `MatchResultController`, `GameResultController`, `GameController`
- **New** `GameRepository::hasNonPlayedGameInDivision()` and `DivisionRepository::hasNonFinalizedDivisionInSeason()`
- **New** `Season.isFinalized` field + migration `Version20260513100000`
- `is_finalized` exposed in all season API responses
- **Bugfix** `calculateSeasonGameStats` used `'joué'` instead of `'played'` — always returned 0% completion
- Worktree autoload override in `tests/bootstrap.php`

## Test plan

- [x] 9 new functional tests in `SeasonClosureTest` — all passing
- [x] No regressions in existing functional test suite (pre-existing failures unchanged)
- [ ] Run `php bin/console doctrine:migrations:migrate` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)