### PR TITLE
feat(season): endpoint admin de clôture manuelle (#32)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ Game → Game (winnerToGame / loserToGame : progression de l'arbre)
 - `GET /api/seasons/current/week` — current week number
 - `GET /api/seasons/{id}/completion` — season completion stats
 - `GET /api/seasons/{id}/teams` — teams registered for a season
+- `POST /api/seasons/{id}/close` — clôture manuelle admin : finalise toutes les divisions + la saison (refuse 409 si déjà finalisée ou si un match n'est pas joué) ; complète l'auto-clôture de `SeasonClosureService`
 
 ### 6. Divisions (`DivisionController`)
 - CRUD on divisions (`/api/divisions`)

--- a/src/Controller/SeasonController.php
+++ b/src/Controller/SeasonController.php
@@ -16,6 +16,7 @@ use App\Repository\TeamStatRepository;
 use App\Repository\RegistrationRepository;
 use Doctrine\ORM\EntityManagerInterface as EntityManager;
 use App\Service\AuthenticationService;
+use App\Service\SeasonClosureService;
 
 #[Route('/api')]
 class SeasonController extends BaseController
@@ -267,6 +268,18 @@ class SeasonController extends BaseController
         }
 
         return $this->securedUpdateEntity($season);
+    }
+
+    #[Route('/seasons/{id}/close', name: 'app_season_close', methods: ['POST'], requirements: ['id' => '\d+'])]
+    public function closeSeason(int $id, SeasonClosureService $seasonClosureService): JsonResponse
+    {
+        $this->checkUserRole('ROLE_ADMIN');
+
+        $season = $this->findEntityOrFail('App\Entity\Season', $id, 'Season');
+
+        $seasonClosureService->closeSeason($season);
+
+        return $this->json($this->formatEntityData($season));
     }
 
     #[Route('/seasons/{id}', name: 'app_season_delete', methods: ['DELETE'], requirements: ['id' => '\d+'])]

--- a/src/Service/SeasonClosureService.php
+++ b/src/Service/SeasonClosureService.php
@@ -5,6 +5,7 @@ namespace App\Service;
 use App\Entity\Division;
 use App\Entity\Game;
 use App\Entity\Season;
+use App\Exception\ApiProblemException;
 use App\Repository\DivisionRepository;
 use App\Repository\GameRepository;
 use App\Repository\TeamStatRepository;
@@ -31,6 +32,41 @@ class SeasonClosureService
         }
 
         $this->tryFinalizeDivision($division);
+    }
+
+    /**
+     * Clôture manuelle d'une saison par un admin : finalise toutes les divisions
+     * puis la saison. Refuse si la saison est déjà finalisée ou si un match
+     * n'est pas encore joué.
+     *
+     * @throws ApiProblemException
+     */
+    public function closeSeason(Season $season): void
+    {
+        if ($season->isFinalized()) {
+            throw ApiProblemException::conflict('Season is already finalized');
+        }
+
+        $divisions = $this->divisionRepository->findBy(['season' => $season]);
+
+        foreach ($divisions as $division) {
+            if ($this->gameRepository->hasNonPlayedGameInDivision($division)) {
+                throw ApiProblemException::conflict('Cannot close season: some games are not yet played');
+            }
+        }
+
+        foreach ($divisions as $division) {
+            if (!$division->isFinalized()) {
+                $division->setIsFinalized(true);
+            }
+        }
+        $season->setIsFinalized(true);
+        $this->entityManager->flush();
+
+        foreach ($divisions as $division) {
+            $this->notifyDivisionFinalized($division);
+        }
+        $this->notifySeasonFinalized($season);
     }
 
     private function tryFinalizeDivision(Division $division): void

--- a/tests/Functional/Controller/SeasonClosureTest.php
+++ b/tests/Functional/Controller/SeasonClosureTest.php
@@ -278,6 +278,77 @@ class SeasonClosureTest extends ApiTestCase
     }
 
     // ========================================================================
+    // Clôture manuelle admin (POST /api/seasons/{id}/close)
+    // ========================================================================
+
+    public function testAdminCanCloseSeasonWhenAllGamesPlayed(): void
+    {
+        $ctx = $this->createBaseContext(1);
+
+        $ctx['game']->setStatus($ctx['playedStatus']);
+        $this->entityManager->flush();
+
+        $this->client->loginUser($ctx['admin'], 'api');
+
+        $response = $this->jsonRequest('POST', '/api/seasons/' . $ctx['season']->getId() . '/close');
+
+        $this->assertResponseStatusCode(200);
+        $this->assertTrue($response['is_finalized']);
+
+        $this->entityManager->refresh($ctx['season']);
+        $this->entityManager->refresh($ctx['division']);
+        $this->assertTrue($ctx['season']->isFinalized());
+        $this->assertTrue($ctx['division']->isFinalized());
+    }
+
+    public function testCloseSeasonBlockedWhenGamesNotPlayed(): void
+    {
+        $ctx = $this->createBaseContext(1);
+
+        $this->client->loginUser($ctx['admin'], 'api');
+
+        $response = $this->jsonRequest('POST', '/api/seasons/' . $ctx['season']->getId() . '/close');
+
+        $this->assertResponseStatusCode(409);
+        $this->assertStringContainsString('Cannot close season', $response['detail']);
+
+        $this->entityManager->refresh($ctx['season']);
+        $this->assertFalse($ctx['season']->isFinalized());
+    }
+
+    public function testCloseSeasonBlockedWhenAlreadyFinalized(): void
+    {
+        $ctx = $this->createBaseContext(1);
+
+        $ctx['season']->setIsFinalized(true);
+        $this->entityManager->flush();
+
+        $this->client->loginUser($ctx['admin'], 'api');
+
+        $response = $this->jsonRequest('POST', '/api/seasons/' . $ctx['season']->getId() . '/close');
+
+        $this->assertResponseStatusCode(409);
+        $this->assertStringContainsString('already finalized', $response['detail']);
+    }
+
+    public function testCloseSeasonRequiresAdmin(): void
+    {
+        $ctx = $this->createBaseContext(1);
+
+        $ctx['game']->setStatus($ctx['playedStatus']);
+        $this->entityManager->flush();
+
+        $this->client->loginUser($ctx['captain1'], 'api');
+
+        $this->jsonRequest('POST', '/api/seasons/' . $ctx['season']->getId() . '/close');
+
+        $this->assertResponseStatusCode(403);
+
+        $this->entityManager->refresh($ctx['season']);
+        $this->assertFalse($ctx['season']->isFinalized());
+    }
+
+    // ========================================================================
     // is_finalized exposé dans les réponses API
     // ========================================================================
 


### PR DESCRIPTION
## Résumé

Complète la tâche #32 en ajoutant la **clôture manuelle de saison** par un admin, en complément de l'auto-clôture déjà en place (`SeasonClosureService`).

## Changements

- `SeasonClosureService::closeSeason(Season)` — valide, finalise toutes les divisions puis la saison, envoie les notifications push
- `SeasonController` — route `POST /api/seasons/{id}/close` gardée par `ROLE_ADMIN`
- Refus `409` si la saison est déjà finalisée **ou** si un match n'est pas encore joué
- 4 tests fonctionnels : succès, matchs en attente, saison déjà finalisée, accès non-admin

## Tests

Suite `SeasonClosureTest` : 13/13 verts.

> Note : 2 échecs pré-existants dans le repo (`testGetDivisionBySeasonEmpty`, `testGetSeasonCompletion`) sont indépendants de cette PR.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)