### PR TITLE
test: couvrir les endpoints teams et pourcentage de SeasonController

### DIFF
--- a/src/Controller/SeasonController.php
+++ b/src/Controller/SeasonController.php
@@ -103,7 +103,6 @@ class SeasonController extends AbstractController
         return $this->json($games);
     }
 
-    // TODO: need to be test with fake data
     #[Route('/season/{id}/teams', name: 'app_season_teams', methods: ['GET'])]
     public function getSeasonTeams(Season $season, RegistrationRepository $registrationRepository): JsonResponse
     {
@@ -125,7 +124,6 @@ class SeasonController extends AbstractController
         return $this->json($data);
     }
 
-    //TODO: need to be tested
     #[Route('/season/{id}/pourcent/{decimal}', name: 'app_season_pourcent', methods: ['GET'])]
     public function getFinishedMatchPourcent(Season $season, DivisionRepository $divisionRepository, GameRepository $gameRepository, GameStatusRepository $gameStatusRepository, int $decimal): JsonResponse
     {

--- a/tests/Controller/SeasonControllerTest.php
+++ b/tests/Controller/SeasonControllerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Controller\SeasonController;
+use App\Entity\Division;
+use App\Entity\Game;
+use App\Entity\GameStatus;
+use App\Entity\Registration;
+use App\Entity\Season;
+use App\Entity\Team;
+use App\Repository\DivisionRepository;
+use App\Repository\GameRepository;
+use App\Repository\GameStatusRepository;
+use App\Repository\RegistrationRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+final class SeasonControllerTest extends TestCase
+{
+    private function makeController(): SeasonController
+    {
+        $controller = new SeasonController();
+        // Conteneur sans service "serializer" : AbstractController::json()
+        // retombe alors sur une JsonResponse simple, suffisante pour les tests.
+        $controller->setContainer(new Container());
+
+        return $controller;
+    }
+
+    private function makeSeason(): Season
+    {
+        return (new Season())
+            ->setName('Saison I')
+            ->setStartDate(new \DateTimeImmutable('2025-03-01'))
+            ->setEndDate(new \DateTimeImmutable('2025-05-01'));
+    }
+
+    private function decode(JsonResponse $response): mixed
+    {
+        return json_decode((string) $response->getContent(), true);
+    }
+
+    public function testGetSeasonTeamsReturnsSeasonWithRegisteredTeams(): void
+    {
+        $season = $this->makeSeason();
+
+        $reg1 = (new Registration())->setSeason($season)->setTeam((new Team())->setName('Les Baguettes'));
+        $reg2 = (new Registration())->setSeason($season)->setTeam((new Team())->setName('Les Croissants'));
+
+        $registrationRepository = $this->createMock(RegistrationRepository::class);
+        $registrationRepository->expects(self::once())
+            ->method('findBy')
+            ->with(['season' => $season])
+            ->willReturn([$reg1, $reg2]);
+
+        $response = $this->makeController()->getSeasonTeams($season, $registrationRepository);
+        $data = $this->decode($response);
+
+        self::assertSame('Saison I', $data['name']);
+        self::assertSame('01-03-2025', $data['start_date']);
+        self::assertSame('01-05-2025', $data['end_date']);
+        self::assertCount(2, $data['teams']);
+        self::assertSame(['Les Baguettes', 'Les Croissants'], array_column($data['teams'], 'name'));
+    }
+
+    public function testGetSeasonTeamsWithNoRegistrations(): void
+    {
+        $season = $this->makeSeason();
+
+        $registrationRepository = $this->createMock(RegistrationRepository::class);
+        $registrationRepository->method('findBy')->willReturn([]);
+
+        $data = $this->decode($this->makeController()->getSeasonTeams($season, $registrationRepository));
+
+        self::assertSame([], $data['teams']);
+    }
+
+    public function testGetFinishedMatchPourcentComputesPercentage(): void
+    {
+        $season = $this->makeSeason();
+        $division = (new Division())->setName('D1');
+        $played = (new GameStatus())->setName('joué');
+        $toPlay = (new GameStatus())->setName('à jouer');
+
+        $game1 = (new Game())->setStatus($played);
+        $game2 = (new Game())->setStatus($played);
+        $game3 = (new Game())->setStatus($toPlay);
+        $game4 = (new Game())->setStatus($toPlay);
+
+        $divisionRepository = $this->createMock(DivisionRepository::class);
+        $divisionRepository->method('findBy')->with(['season' => $season])->willReturn([$division]);
+
+        $gameRepository = $this->createMock(GameRepository::class);
+        $gameRepository->method('findBy')->with(['division' => $division])->willReturn([$game1, $game2, $game3, $game4]);
+
+        $gameStatusRepository = $this->createMock(GameStatusRepository::class);
+        $gameStatusRepository->method('findOneBy')->with(['name' => 'joué'])->willReturn($played);
+
+        $response = $this->makeController()->getFinishedMatchPourcent(
+            $season,
+            $divisionRepository,
+            $gameRepository,
+            $gameStatusRepository,
+            2
+        );
+        $data = $this->decode($response);
+
+        self::assertSame(4, $data['total']);
+        self::assertSame(2, $data['finished']);
+        self::assertSame('50.00', $data['pourcent']);
+    }
+
+    public function testGetFinishedMatchPourcentWithNoGamesIsZero(): void
+    {
+        $season = $this->makeSeason();
+
+        $divisionRepository = $this->createMock(DivisionRepository::class);
+        $divisionRepository->method('findBy')->willReturn([]);
+
+        $gameRepository = $this->createMock(GameRepository::class);
+        $gameStatusRepository = $this->createMock(GameStatusRepository::class);
+
+        $data = $this->decode($this->makeController()->getFinishedMatchPourcent(
+            $season,
+            $divisionRepository,
+            $gameRepository,
+            $gameStatusRepository,
+            0
+        ));
+
+        self::assertSame(0, $data['total']);
+        self::assertSame(0, $data['finished']);
+        self::assertSame('0', $data['pourcent']);
+    }
+}


### PR DESCRIPTION
## Contexte
Résout les TODO « need to be tested » de `SeasonController` (issue de couverture des tests).

## Changements
- Tests unitaires pour `getSeasonTeams` (saison + équipes inscrites, cas vide).
- Tests unitaires pour `getFinishedMatchPourcent` (calcul du pourcentage, cas sans match).
- Repositories mockés (PHPUnit), pas de dépendance base de données.
- Suppression des deux TODO résolus.

## Non couvert
`getSeasonGamesByStatus` (ligne ~89) conserve son TODO : sa logique de comparaison `getGames() === status` relève d'une question de design (« maybe it's useless ») à trancher avant de figer un test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)