### PR TITLE
feat(api): endpoint GET /games/unscheduled

### DIFF
--- a/src/Controller/GameController.php
+++ b/src/Controller/GameController.php
@@ -36,7 +36,38 @@ class GameController extends AbstractController
         return $this->json($data);
     }
 
-    #[Route('/games/{divisionId}', name: 'app_game_division', methods: ['GET'])]
+    #[Route('/games/unscheduled', name: 'app_game_unscheduled', methods: ['GET'])]
+    public function getUnscheduledGames(Request $request, GameRepository $gameRepository): JsonResponse
+    {
+        $week = $request->query->get('week');
+        $seasonId = $request->query->get('season_id');
+
+        if ($week === null || !ctype_digit((string) $week)) {
+            return $this->json(['error' => 'Missing or invalid "week" query parameter'], 400);
+        }
+        if ($seasonId === null || !ctype_digit((string) $seasonId)) {
+            return $this->json(['error' => 'Missing or invalid "season_id" query parameter'], 400);
+        }
+
+        $games = $gameRepository->findUnscheduled((int) $week, (int) $seasonId);
+
+        $data = array_map(function (Game $game) {
+            return [
+                'id' => $game->getId(),
+                'week' => $game->getWeek(),
+                'division' => $game->getDivision()?->getName(),
+                'team1' => $game->getTeam1()?->getName(),
+                'team2' => $game->getTeam2()?->getName(),
+                'team1_captain_discord' => $game->getTeam1()?->getCapitain()?->getDiscord(),
+                'team2_captain_discord' => $game->getTeam2()?->getCapitain()?->getDiscord(),
+                'status' => $game->getStatus()?->getName(),
+            ];
+        }, $games);
+
+        return $this->json($data);
+    }
+
+    #[Route('/games/{divisionId}', name: 'app_game_division', methods: ['GET'], requirements: ['divisionId' => '\d+'])]
     public function getGamesByDivisionId(GameRepository $gameRepository, int $divisionId): JsonResponse
     {
         $games = $gameRepository->findBy(['division' => $divisionId]);

--- a/src/Repository/GameRepository.php
+++ b/src/Repository/GameRepository.php
@@ -16,6 +16,25 @@ class GameRepository extends ServiceEntityRepository
         parent::__construct($registry, Game::class);
     }
 
+    /**
+     * Matchs sans date planifiée (date IS NULL) pour une semaine et une saison données.
+     *
+     * @return Game[]
+     */
+    public function findUnscheduled(int $week, int $seasonId): array
+    {
+        return $this->createQueryBuilder('g')
+            ->innerJoin('g.division', 'd')
+            ->andWhere('g.date IS NULL')
+            ->andWhere('g.week = :week')
+            ->andWhere('d.season = :season')
+            ->setParameter('week', $week)
+            ->setParameter('season', $seasonId)
+            ->orderBy('g.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
     //    /**
     //     * @return Game[] Returns an array of Game objects
     //     */

--- a/tests/Controller/GameControllerTest.php
+++ b/tests/Controller/GameControllerTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Controller\GameController;
+use App\Entity\Division;
+use App\Entity\Game;
+use App\Entity\GameStatus;
+use App\Entity\Player;
+use App\Entity\Team;
+use App\Repository\GameRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+final class GameControllerTest extends TestCase
+{
+    private function makeController(): GameController
+    {
+        $controller = new GameController();
+        $controller->setContainer(new Container());
+
+        return $controller;
+    }
+
+    private function decode(JsonResponse $response): mixed
+    {
+        return json_decode((string) $response->getContent(), true);
+    }
+
+    private function makeTeam(string $name, ?string $captainDiscord): Team
+    {
+        $team = (new Team())->setName($name);
+        if ($captainDiscord !== null) {
+            $team->setCapitain((new Player())->setName('Cap ' . $name)->setDiscord($captainDiscord));
+        }
+
+        return $team;
+    }
+
+    public function testReturnsUnscheduledGamesForWeekAndSeason(): void
+    {
+        $division = (new Division())->setName('D1');
+        $status = (new GameStatus())->setName('à planifier');
+
+        $game = (new Game())
+            ->setWeek(3)
+            ->setDivision($division)
+            ->setStatus($status)
+            ->setTeam1($this->makeTeam('Alpha', '111'))
+            ->setTeam2($this->makeTeam('Beta', '222'));
+
+        $gameRepository = $this->createMock(GameRepository::class);
+        $gameRepository->expects(self::once())
+            ->method('findUnscheduled')
+            ->with(3, 2)
+            ->willReturn([$game]);
+
+        $request = new Request(['week' => '3', 'season_id' => '2']);
+        $data = $this->decode($this->makeController()->getUnscheduledGames($request, $gameRepository));
+
+        self::assertCount(1, $data);
+        self::assertSame(3, $data[0]['week']);
+        self::assertSame('D1', $data[0]['division']);
+        self::assertSame('Alpha', $data[0]['team1']);
+        self::assertSame('Beta', $data[0]['team2']);
+        self::assertSame('111', $data[0]['team1_captain_discord']);
+        self::assertSame('222', $data[0]['team2_captain_discord']);
+        self::assertSame('à planifier', $data[0]['status']);
+    }
+
+    public function testCaptainDiscordIsNullWhenNoCaptain(): void
+    {
+        $game = (new Game())
+            ->setWeek(1)
+            ->setDivision((new Division())->setName('D2'))
+            ->setStatus((new GameStatus())->setName('à planifier'))
+            ->setTeam1($this->makeTeam('Gamma', null))
+            ->setTeam2($this->makeTeam('Delta', null));
+
+        $gameRepository = $this->createMock(GameRepository::class);
+        $gameRepository->method('findUnscheduled')->willReturn([$game]);
+
+        $request = new Request(['week' => '1', 'season_id' => '1']);
+        $data = $this->decode($this->makeController()->getUnscheduledGames($request, $gameRepository));
+
+        self::assertNull($data[0]['team1_captain_discord']);
+        self::assertNull($data[0]['team2_captain_discord']);
+    }
+
+    public function testMissingWeekReturns400(): void
+    {
+        $gameRepository = $this->createMock(GameRepository::class);
+        $gameRepository->expects(self::never())->method('findUnscheduled');
+
+        $request = new Request(['season_id' => '2']);
+        $response = $this->makeController()->getUnscheduledGames($request, $gameRepository);
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertArrayHasKey('error', $this->decode($response));
+    }
+
+    public function testNonNumericSeasonIdReturns400(): void
+    {
+        $gameRepository = $this->createMock(GameRepository::class);
+        $gameRepository->expects(self::never())->method('findUnscheduled');
+
+        $request = new Request(['week' => '3', 'season_id' => 'abc']);
+        $response = $this->makeController()->getUnscheduledGames($request, $gameRepository);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Contexte
Le scheduler du bot (`scheduler/deadline-check.js`) appelle `GET /games/unscheduled?week=X&season_id=Y`, endpoint qui n'existait pas encore côté API.

## Changements
- **`GameRepository::findUnscheduled(week, seasonId)`** : matchs sans date planifiée (`date IS NULL`) pour une semaine + une saison (jointure `division.season`).
- **`GET /games/unscheduled`** : validation des query params `week` / `season_id` (400 si absents ou non numériques), sinon renvoie la liste.
- Route déclarée **avant** `/games/{divisionId}` + contrainte `\d+` sur `divisionId` pour éviter que `unscheduled` soit capturé comme id de division.
- Réponse : `id, week, division, team1, team2, team1_captain_discord, team2_captain_discord, status` — les discord des capitaines débloquent aussi la notification du bot (TODO `deadline-check.js`).
- Tests unitaires (repository mocké, sans base de données).

## Exemple
`GET /games/unscheduled?week=3&season_id=2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)