### PR TITLE
feat(api): endpoints /season/current/week et PATCH /games/{id}/schedule

### DIFF
--- a/src/Controller/GameController.php
+++ b/src/Controller/GameController.php
@@ -148,6 +148,37 @@ class GameController extends AbstractController
         return $this->json($data);
     }
 
+    #[Route('/games/{id}/schedule', name: 'app_game_schedule', methods: ['PATCH'], requirements: ['id' => '\d+'])]
+    public function scheduleGame(Request $request, Game $game, EntityManager $em): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        if (!is_array($data) || !isset($data['date']) || !is_string($data['date'])) {
+            return $this->json(['error' => 'Missing or invalid "date" field'], 400);
+        }
+
+        try {
+            $date = new \DateTime($data['date']);
+        } catch (\Exception) {
+            return $this->json(['error' => 'Invalid "date" format'], 400);
+        }
+
+        $game->setDate($date);
+        $em->flush();
+
+        return $this->json([
+            'id' => $game->getId(),
+            'date' => $game->getDate()?->format('Y-m-d H:i:s'),
+            'week' => $game->getWeek(),
+            'team1' => $game->getTeam1()?->getName(),
+            'team2' => $game->getTeam2()?->getName(),
+            'score1' => $game->getScore1(),
+            'score2' => $game->getScore2(),
+            'winner' => $game->getWinner(),
+            'status' => $game->getStatus()?->getName(),
+            'division' => $game->getDivision()?->getName(),
+        ]);
+    }
+
     // #[Route('/game', name: 'app_game_create', methods: ['POST'])]
     // public function createGame(Request $request, TeamRepository $teamRepository, GameStatusRepository $gameStatusRepository, DivisionRepository $divisionRepository, EntityManager $em): JsonResponse
     // {

--- a/src/Controller/SeasonController.php
+++ b/src/Controller/SeasonController.php
@@ -51,7 +51,37 @@ class SeasonController extends AbstractController
         return $this->json($data);
     }
 
-    #[Route('/season/{id}', name: 'app_season_show', methods: ['GET'])]
+    #[Route('/season/current/week', name: 'app_season_current_week', methods: ['GET'])]
+    public function getCurrentSeasonWeek(SeasonRepository $seasonRepository, GameRepository $gameRepository): JsonResponse
+    {
+        $now = new \DateTime();
+        $season = $seasonRepository->findCurrent($now);
+        if (!$season) {
+            return $this->json(['error' => 'No current season'], 404);
+        }
+
+        $start = $season->getStartDate();
+        $daysSinceStart = null !== $start ? (int) $start->diff($now)->days : 0;
+        $currentWeek = intdiv($daysSinceStart, 7) + 1;
+
+        $maxWeek = $gameRepository->findMaxWeekForSeason((int) $season->getId());
+        if (null !== $maxWeek && $currentWeek > $maxWeek) {
+            $currentWeek = $maxWeek;
+        }
+        if ($currentWeek < 1) {
+            $currentWeek = 1;
+        }
+
+        return $this->json([
+            'season_id' => $season->getId(),
+            'name' => $season->getName(),
+            'start_date' => $season->getStartDate()?->format('d-m-Y'),
+            'end_date' => $season->getEndDate()?->format('d-m-Y'),
+            'current_week' => $currentWeek,
+        ]);
+    }
+
+    #[Route('/season/{id}', name: 'app_season_show', methods: ['GET'], requirements: ['id' => '\d+'])]
     public function getSeason(Season $season): JsonResponse
     {
         return $this->json([

--- a/src/Repository/GameRepository.php
+++ b/src/Repository/GameRepository.php
@@ -35,6 +35,22 @@ class GameRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    /**
+     * Numéro de semaine le plus élevé du calendrier d'une saison (null si aucun match).
+     */
+    public function findMaxWeekForSeason(int $seasonId): ?int
+    {
+        $max = $this->createQueryBuilder('g')
+            ->select('MAX(g.week)')
+            ->innerJoin('g.division', 'd')
+            ->andWhere('d.season = :season')
+            ->setParameter('season', $seasonId)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return null !== $max ? (int) $max : null;
+    }
+
     //    /**
     //     * @return Game[] Returns an array of Game objects
     //     */

--- a/src/Repository/SeasonRepository.php
+++ b/src/Repository/SeasonRepository.php
@@ -16,6 +16,22 @@ class SeasonRepository extends ServiceEntityRepository
         parent::__construct($registry, Season::class);
     }
 
+    /**
+     * Saison « en cours » : dont l'intervalle [startDate, endDate] contient la date donnée.
+     * En cas de chevauchement, la plus récente est retournée.
+     */
+    public function findCurrent(\DateTimeInterface $now): ?Season
+    {
+        return $this->createQueryBuilder('s')
+            ->andWhere('s.startDate <= :now')
+            ->andWhere('s.endDate >= :now')
+            ->setParameter('now', $now)
+            ->orderBy('s.startDate', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
     //    /**
     //     * @return Season[] Returns an array of Season objects
     //     */

--- a/tests/Controller/GameControllerTest.php
+++ b/tests/Controller/GameControllerTest.php
@@ -9,6 +9,7 @@ use App\Entity\GameStatus;
 use App\Entity\Player;
 use App\Entity\Team;
 use App\Repository\GameRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -108,6 +109,57 @@ final class GameControllerTest extends TestCase
 
         $request = new Request(['week' => '3', 'season_id' => 'abc']);
         $response = $this->makeController()->getUnscheduledGames($request, $gameRepository);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    private function makeScheduledGame(): Game
+    {
+        return (new Game())
+            ->setWeek(4)
+            ->setDivision((new Division())->setName('D1'))
+            ->setStatus((new GameStatus())->setName('à planifier'))
+            ->setTeam1($this->makeTeam('Alpha', '111'))
+            ->setTeam2($this->makeTeam('Beta', '222'));
+    }
+
+    public function testScheduleGameSetsDateAndPersists(): void
+    {
+        $game = $this->makeScheduledGame();
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('flush');
+
+        $request = new Request(content: (string) json_encode(['date' => '2025-09-01T21:00:00Z']));
+        $data = $this->decode($this->makeController()->scheduleGame($request, $game, $em));
+
+        self::assertSame('2025-09-01 21:00:00', $data['date']);
+        self::assertSame('Alpha', $data['team1']);
+        self::assertInstanceOf(\DateTimeInterface::class, $game->getDate());
+    }
+
+    public function testScheduleGameWithMissingDateReturns400(): void
+    {
+        $game = $this->makeScheduledGame();
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::never())->method('flush');
+
+        $request = new Request(content: (string) json_encode([]));
+        $response = $this->makeController()->scheduleGame($request, $game, $em);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    public function testScheduleGameWithInvalidDateReturns400(): void
+    {
+        $game = $this->makeScheduledGame();
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::never())->method('flush');
+
+        $request = new Request(content: (string) json_encode(['date' => 'not-a-date']));
+        $response = $this->makeController()->scheduleGame($request, $game, $em);
 
         self::assertSame(400, $response->getStatusCode());
     }

--- a/tests/Controller/SeasonControllerTest.php
+++ b/tests/Controller/SeasonControllerTest.php
@@ -13,6 +13,7 @@ use App\Repository\DivisionRepository;
 use App\Repository\GameRepository;
 use App\Repository\GameStatusRepository;
 use App\Repository\RegistrationRepository;
+use App\Repository\SeasonRepository;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -133,5 +134,58 @@ final class SeasonControllerTest extends TestCase
         self::assertSame(0, $data['total']);
         self::assertSame(0, $data['finished']);
         self::assertSame('0', $data['pourcent']);
+    }
+
+    public function testGetCurrentSeasonWeekComputesWeekFromStartDate(): void
+    {
+        // Saison démarrée il y a 15 jours -> semaine 3 (floor(15 / 7) + 1).
+        $season = (new Season())
+            ->setName('Saison en cours')
+            ->setStartDate(new \DateTime('-15 days'))
+            ->setEndDate(new \DateTime('+15 days'));
+
+        $seasonRepository = $this->createMock(SeasonRepository::class);
+        $seasonRepository->expects(self::once())->method('findCurrent')->willReturn($season);
+
+        $gameRepository = $this->createMock(GameRepository::class);
+        $gameRepository->method('findMaxWeekForSeason')->willReturn(10);
+
+        $data = $this->decode($this->makeController()->getCurrentSeasonWeek($seasonRepository, $gameRepository));
+
+        self::assertSame(3, $data['current_week']);
+        self::assertSame('Saison en cours', $data['name']);
+        self::assertArrayHasKey('season_id', $data);
+    }
+
+    public function testGetCurrentSeasonWeekIsClampedToMaxScheduledWeek(): void
+    {
+        $season = (new Season())
+            ->setName('Saison presque finie')
+            ->setStartDate(new \DateTime('-60 days'))
+            ->setEndDate(new \DateTime('+5 days'));
+
+        $seasonRepository = $this->createMock(SeasonRepository::class);
+        $seasonRepository->method('findCurrent')->willReturn($season);
+
+        $gameRepository = $this->createMock(GameRepository::class);
+        $gameRepository->method('findMaxWeekForSeason')->willReturn(6);
+
+        $data = $this->decode($this->makeController()->getCurrentSeasonWeek($seasonRepository, $gameRepository));
+
+        // ~9 semaines écoulées mais le calendrier s'arrête à la semaine 6.
+        self::assertSame(6, $data['current_week']);
+    }
+
+    public function testGetCurrentSeasonWeekReturns404WhenNoCurrentSeason(): void
+    {
+        $seasonRepository = $this->createMock(SeasonRepository::class);
+        $seasonRepository->method('findCurrent')->willReturn(null);
+
+        $gameRepository = $this->createMock(GameRepository::class);
+        $gameRepository->expects(self::never())->method('findMaxWeekForSeason');
+
+        $response = $this->makeController()->getCurrentSeasonWeek($seasonRepository, $gameRepository);
+
+        self::assertSame(404, $response->getStatusCode());
     }
 }


### PR DESCRIPTION
## Contexte
Derniers endpoints appelés par le bot mais absents de l'API (`scheduler/deadline-check.js`, `scheduler/weekly-messages.js`).

## Changements
### `GET /season/current/week`
- Saison « en cours » = celle dont `[startDate, endDate]` contient aujourd'hui (`SeasonRepository::findCurrent`).
- `current_week` calculé depuis `startDate` (`floor(jours/7) + 1`), borné au numéro de semaine max du calendrier (`GameRepository::findMaxWeekForSeason`).
- **404** si aucune saison en cours (le bot le gère via `!response.ok`).
- Réponse : `{ season_id, name, start_date, end_date, current_week }`.

### `PATCH /games/{id}/schedule`
- Fixe la date d'un match : body `{ date }` (ISO). **400** si absente/invalide, 404 auto si l'id n'existe pas.
- Écriture ciblée (uniquement la date) via `EntityManager::flush`.
- Route `\d+` pour ne pas entrer en conflit avec les autres routes `/games/...`.

## Tests
Unitaires (repositories + EntityManager mockés) : calcul et clamp de la semaine, 404 sans saison, set de date, 400 date manquante/invalide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)