### PR TITLE
feat(teams): gestion du roster par les capitaines (#30)

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -73,6 +73,8 @@ security:
         - { path: ^/api/users/me, roles: ROLE_USER, methods: [GET] }
         # Team management endpoints accessible to any authenticated user
         - { path: ^/api/teams/\d+/members, roles: ROLE_USER }
+        # Roster (players) management by team captains — ROLE_USER, not ROLE_API
+        - { path: ^/api/teams/\d+/players, roles: ROLE_USER }
         # Push subscription endpoints accessible to any authenticated user (ROLE_USER, not ROLE_API)
         - { path: ^/api/push/subscribe, roles: ROLE_USER }
         - { path: ^/api, roles: ROLE_API, methods: [POST, PUT, PATCH, DELETE] }

--- a/src/Controller/TeamController.php
+++ b/src/Controller/TeamController.php
@@ -403,4 +403,86 @@ class TeamController extends BaseController
             'role' => $targetMembership->getRole(),
         ]);
     }
+
+    // ==========================================
+    // Team Roster (Players) Management by captains (ROLE_USER)
+    //
+    // Un capitaine peut gérer le roster (entités Player) de SA propre équipe
+    // sans avoir besoin de ROLE_API. Complète la gestion des membres (comptes
+    // User liés à Discord) par la gestion des joueurs de feuille de match.
+    // ==========================================
+
+    /**
+     * S'assure que l'utilisateur authentifié est capitaine de l'équipe donnée.
+     */
+    private function assertCurrentUserIsCaptain(Team $team, TeamMemberRepository $teamMemberRepository): void
+    {
+        try {
+            $currentUser = $this->getAuthenticatedUser();
+        } catch (\Symfony\Component\Security\Core\Exception\AccessDeniedException $e) {
+            throw ApiProblemException::unauthorized($e->getMessage());
+        }
+
+        $membership = $teamMemberRepository->findByTeamAndUser($team, $currentUser);
+        if (!$membership || !$membership->isCaptain()) {
+            throw ApiProblemException::forbidden('Only team captains can manage the roster');
+        }
+    }
+
+    #[Route('/teams/{teamId}/players', name: 'app_team_add_player', methods: ['POST'], requirements: ['teamId' => '\d+'])]
+    public function addTeamPlayer(int $teamId, Request $request, TeamMemberRepository $teamMemberRepository): JsonResponse
+    {
+        $team = $this->findEntityOrFail(Team::class, $teamId, 'Team');
+        $this->assertCurrentUserIsCaptain($team, $teamMemberRepository);
+
+        $data = $this->getRequestData($request);
+
+        if (!isset($data['name']) || empty(trim((string) $data['name']))) {
+            throw ApiProblemException::validationError('Player name is required', [['field' => 'name', 'message' => 'This value should not be blank.']]);
+        }
+
+        $name = trim($data['name']);
+        if (mb_strlen($name) < 2 || mb_strlen($name) > 50) {
+            throw ApiProblemException::validationError('Player name must be between 2 and 50 characters', [['field' => 'name', 'message' => 'This value must be between 2 and 50 characters.']]);
+        }
+
+        $player = new Player();
+        $player->setName($name);
+        $player->setDiscord(isset($data['discord']) ? (string) $data['discord'] : null);
+        $player->setTeam($team);
+
+        $this->entityManager->persist($player);
+        $this->entityManager->flush();
+
+        $this->logger->info('Player added to roster by captain', ['team' => $teamId, 'player' => $player->getId()]);
+
+        $response = $this->json([
+            'id' => $player->getId(),
+            'name' => $player->getName(),
+            'discord' => $player->getDiscord(),
+            'team_id' => $team->getId(),
+            'team_name' => $team->getName(),
+        ], 201);
+        $response->headers->set('Location', '/api/players/' . $player->getId());
+        return $response;
+    }
+
+    #[Route('/teams/{teamId}/players/{playerId}', name: 'app_team_remove_player', methods: ['DELETE'], requirements: ['teamId' => '\d+', 'playerId' => '\d+'])]
+    public function removeTeamPlayer(int $teamId, int $playerId, PlayerRepository $playerRepository, TeamMemberRepository $teamMemberRepository): JsonResponse
+    {
+        $team = $this->findEntityOrFail(Team::class, $teamId, 'Team');
+        $this->assertCurrentUserIsCaptain($team, $teamMemberRepository);
+
+        $player = $playerRepository->find($playerId);
+        if (!$player || !$player->getTeam() || $player->getTeam()->getId() !== $team->getId()) {
+            throw ApiProblemException::notFound('Player not found in this team');
+        }
+
+        $this->entityManager->remove($player);
+        $this->entityManager->flush();
+
+        $this->logger->info('Player removed from roster by captain', ['team' => $teamId, 'player' => $playerId]);
+
+        return new JsonResponse(null, 204);
+    }
 }

--- a/src/EventListener/ApiSecurityListener.php
+++ b/src/EventListener/ApiSecurityListener.php
@@ -90,6 +90,11 @@ class ApiSecurityListener
             return true;
         }
 
+        // Match /api/teams/{id}/players and /api/teams/{id}/players/{playerId}
+        if (preg_match('#^/api/teams/\d+/players(/\d+)?$#', $path)) {
+            return true;
+        }
+
         return false;
     }
 }

--- a/tests/Functional/Controller/TeamControllerTest.php
+++ b/tests/Functional/Controller/TeamControllerTest.php
@@ -192,4 +192,108 @@ class TeamControllerTest extends ApiTestCase
         $this->assertNull($response['captain']);
         $this->assertNull($response['captain_id']);
     }
+
+    // ==========================================
+    // Roster management by captains (issue api#30)
+    // ==========================================
+
+    /**
+     * Crée une équipe et y attache un utilisateur avec le rôle donné, puis
+     * authentifie le client comme cet utilisateur (firewall « api »).
+     */
+    private function createTeamWithAuthenticatedMember(string $role): Team
+    {
+        $user = new \App\Entity\User();
+        $user->setUsername('cap_' . uniqid());
+        $user->setPassword('hashed');
+        $user->setRoles(['ROLE_USER']);
+        $user->setIsActive(true);
+        $user->setDiscordId('discord_' . uniqid());
+        $this->entityManager->persist($user);
+
+        $team = new Team();
+        $team->setName('Roster Team');
+        $this->entityManager->persist($team);
+
+        $member = new \App\Entity\TeamMember();
+        $member->setUser($user);
+        $member->setRole($role);
+        $team->addMember($member);
+        $this->entityManager->persist($member);
+
+        $this->entityManager->flush();
+
+        $this->client->loginUser($user, 'api');
+
+        return $team;
+    }
+
+    public function testCaptainCanAddPlayerToRoster(): void
+    {
+        $team = $this->createTeamWithAuthenticatedMember(\App\Entity\TeamMember::ROLE_CAPTAIN);
+
+        $response = $this->jsonRequest('POST', '/api/teams/' . $team->getId() . '/players', [
+            'name' => 'Nouveau Joueur',
+            'discord' => 'joueur#4242',
+        ]);
+
+        $this->assertResponseStatusCode(201);
+        $this->assertEquals('Nouveau Joueur', $response['name']);
+        $this->assertEquals('joueur#4242', $response['discord']);
+        $this->assertEquals($team->getId(), $response['team_id']);
+    }
+
+    public function testNonCaptainCannotAddPlayerToRoster(): void
+    {
+        $team = $this->createTeamWithAuthenticatedMember(\App\Entity\TeamMember::ROLE_MEMBER);
+
+        $this->jsonRequest('POST', '/api/teams/' . $team->getId() . '/players', [
+            'name' => 'Joueur Refusé',
+        ]);
+
+        $this->assertResponseStatusCode(403);
+    }
+
+    public function testAddPlayerRequiresName(): void
+    {
+        $team = $this->createTeamWithAuthenticatedMember(\App\Entity\TeamMember::ROLE_CAPTAIN);
+
+        $this->jsonRequest('POST', '/api/teams/' . $team->getId() . '/players', [
+            'discord' => 'sansnom#0001',
+        ]);
+
+        $this->assertResponseStatusCode(400);
+    }
+
+    public function testCaptainCanRemovePlayerFromRoster(): void
+    {
+        $team = $this->createTeamWithAuthenticatedMember(\App\Entity\TeamMember::ROLE_CAPTAIN);
+
+        $player = new Player();
+        $player->setName('Joueur À Retirer');
+        $player->setTeam($team);
+        $this->entityManager->persist($player);
+        $this->entityManager->flush();
+
+        $this->jsonRequest('DELETE', '/api/teams/' . $team->getId() . '/players/' . $player->getId());
+        $this->assertResponseStatusCode(204);
+    }
+
+    public function testCaptainCannotRemovePlayerFromAnotherTeam(): void
+    {
+        $team = $this->createTeamWithAuthenticatedMember(\App\Entity\TeamMember::ROLE_CAPTAIN);
+
+        $otherTeam = new Team();
+        $otherTeam->setName('Autre Équipe');
+        $this->entityManager->persist($otherTeam);
+
+        $player = new Player();
+        $player->setName('Joueur Externe');
+        $player->setTeam($otherTeam);
+        $this->entityManager->persist($player);
+        $this->entityManager->flush();
+
+        $this->jsonRequest('DELETE', '/api/teams/' . $team->getId() . '/players/' . $player->getId());
+        $this->assertResponseStatusCode(404);
+    }
 }


### PR DESCRIPTION
Résout **#30**.

## Contexte
L'issue demande deux choses :
1. Un capitaine peut ajouter un joueur dans son équipe
2. Un capitaine peut nommer un membre de son équipe comme capitaine

Le point **2** était déjà couvert par `PATCH /api/teams/{teamId}/members/role`. Cette PR ajoute le point **1** (gestion du roster de joueurs).

## Changements
- `POST /api/teams/{teamId}/players` — le capitaine ajoute un `Player` (nom + discord optionnel) à **sa** propre équipe
- `DELETE /api/teams/{teamId}/players/{playerId}` — le capitaine retire un joueur de son équipe
- Ces routes exigent `ROLE_USER` (et non `ROLE_API`) ; la vérification capitaine se fait via `TeamMemberRepository::findByTeamAndUser`
- Règle `access_control` `^/api/teams/\d+/players` → `ROLE_USER`, placée avant le catch-all `ROLE_API`

## Tests
Tests fonctionnels ajoutés dans `TeamControllerTest` : ajout par capitaine (201), refus pour un simple membre (403), nom requis (400), retrait (204), retrait interdit sur une équipe tierce (404).

> ⚠️ Base = `feat/backend-v2-integrated` car les entités `TeamMember`/`User(discord)` ne sont pas encore sur `main` (PR #61).

🤖 Generated with [Claude Code](https://claude.com/claude-code)