### PR TITLE
feat(registration): flux d'inscription des équipes à une saison (#35)

### DIFF
--- a/.env
+++ b/.env
@@ -84,3 +84,8 @@ MATCH_RESULT_REMINDER_HOUR=20
 MATCH_RESULT_DEADLINE_DAY=thursday
 MATCH_RESULT_DEADLINE_HOUR=22
 ###< match result timeout ###
+
+###> season registration ###
+# Nombre minimum de joueurs requis pour inscrire une équipe à une saison
+REGISTRATION_MIN_PLAYERS=3
+###< season registration ###

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -73,6 +73,8 @@ security:
         - { path: ^/api/users/me, roles: ROLE_USER, methods: [GET] }
         # Team management endpoints accessible to any authenticated user
         - { path: ^/api/teams/\d+/members, roles: ROLE_USER }
+        # Season registration by team captains — ROLE_USER, not ROLE_API
+        - { path: ^/api/seasons/\d+/register, roles: ROLE_USER }
         # Push subscription endpoints accessible to any authenticated user (ROLE_USER, not ROLE_API)
         - { path: ^/api/push/subscribe, roles: ROLE_USER }
         - { path: ^/api, roles: ROLE_API, methods: [POST, PUT, PATCH, DELETE] }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,6 +4,8 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
+    # Valeur par défaut de la variable d'environnement (surchargeable via .env / conteneur).
+    env(REGISTRATION_MIN_PLAYERS): '3'
     discord.client_id: '%env(DISCORD_CLIENT_ID)%'
     discord.client_secret: '%env(DISCORD_CLIENT_SECRET)%'
     discord.redirect_uri: '%env(DISCORD_REDIRECT_URI)%'
@@ -16,6 +18,8 @@ parameters:
     match_result.reminder_hour: '%env(int:MATCH_RESULT_REMINDER_HOUR)%'
     match_result.deadline_day: '%env(MATCH_RESULT_DEADLINE_DAY)%'
     match_result.deadline_hour: '%env(int:MATCH_RESULT_DEADLINE_HOUR)%'
+    # Nombre minimum de joueurs qu'une équipe doit avoir pour s'inscrire à une saison.
+    app.registration.min_players: '%env(int:REGISTRATION_MIN_PLAYERS)%'
 
 services:
     # default configuration for services in *this* file

--- a/migrations/Version20260723120000.php
+++ b/migrations/Version20260723120000.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Flux d'inscription des équipes à une saison (issue api#35) :
+ * - registration : statut + dates de création/revue
+ * - season       : fenêtre d'inscription (dates d'ouverture/fermeture)
+ */
+final class Version20260723120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add registration status/dates and season registration window';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE registration ADD status VARCHAR(20) NOT NULL DEFAULT 'pending'");
+        $this->addSql('ALTER TABLE registration ADD created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP');
+        $this->addSql('ALTER TABLE registration ADD reviewed_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
+
+        $this->addSql('ALTER TABLE season ADD registration_open_date DATE DEFAULT NULL');
+        $this->addSql('ALTER TABLE season ADD registration_close_date DATE DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE registration DROP status');
+        $this->addSql('ALTER TABLE registration DROP created_at');
+        $this->addSql('ALTER TABLE registration DROP reviewed_at');
+
+        $this->addSql('ALTER TABLE season DROP registration_open_date');
+        $this->addSql('ALTER TABLE season DROP registration_close_date');
+    }
+}

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -6,7 +6,11 @@ use App\Exception\ApiProblemException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Attribute\Route;
 use App\Entity\Registration;
+use App\Entity\Season;
+use App\Entity\Team;
 use App\Repository\RegistrationRepository;
+use App\Repository\PlayerRepository;
+use App\Repository\TeamMemberRepository;
 use Symfony\Component\HttpFoundation\Request;
 
 #[Route('/api')]
@@ -19,8 +23,13 @@ class RegistrationController extends BaseController
         }
         return [
             'id' => $entity->getId(),
-            'season' => $entity->getSeason()->getName(),
-            'team' => $entity->getTeam()->getName()
+            'season' => $entity->getSeason() ? $entity->getSeason()->getName() : null,
+            'season_id' => $entity->getSeason() ? $entity->getSeason()->getId() : null,
+            'team' => $entity->getTeam() ? $entity->getTeam()->getName() : null,
+            'team_id' => $entity->getTeam() ? $entity->getTeam()->getId() : null,
+            'status' => $entity->getStatus(),
+            'created_at' => $entity->getCreatedAt()->format('Y-m-d H:i:s'),
+            'reviewed_at' => $entity->getReviewedAt()?->format('Y-m-d H:i:s'),
         ];
     }
 
@@ -135,5 +144,110 @@ class RegistrationController extends BaseController
     {
         $registration = $this->findEntityOrFail('App\Entity\Registration', $id, 'Registration');
         return $this->securedDeleteEntity($registration, 'Registration');
+    }
+
+    // ==========================================
+    // Flux d'inscription à une saison (issue api#35)
+    // ==========================================
+
+    /**
+     * POST /api/seasons/{seasonId}/register
+     *
+     * Le capitaine d'une équipe inscrit SON équipe à une saison ouverte.
+     * Body : {"team_id": <id>}. L'inscription est créée au statut "pending"
+     * et devra être validée par un admin.
+     */
+    #[Route('/seasons/{seasonId}/register', name: 'app_season_register_team', methods: ['POST'], requirements: ['seasonId' => '\d+'])]
+    public function registerTeam(
+        int $seasonId,
+        Request $request,
+        RegistrationRepository $registrationRepository,
+        TeamMemberRepository $teamMemberRepository,
+        PlayerRepository $playerRepository
+    ): JsonResponse {
+        try {
+            $currentUser = $this->getAuthenticatedUser();
+        } catch (\Symfony\Component\Security\Core\Exception\AccessDeniedException $e) {
+            throw ApiProblemException::unauthorized($e->getMessage());
+        }
+
+        /** @var Season $season */
+        $season = $this->findEntityOrFail(Season::class, $seasonId, 'Season');
+
+        $data = $this->getRequestData($request);
+        $teamId = $data['team_id'] ?? $data['team'] ?? null;
+        if (!$teamId) {
+            throw ApiProblemException::validationError('team_id is required', [['field' => 'team_id', 'message' => 'This value should not be blank.']]);
+        }
+
+        /** @var Team $team */
+        $team = $this->findEntityOrFail(Team::class, $teamId, 'Team');
+
+        // Seul le capitaine de l'équipe peut l'inscrire.
+        $membership = $teamMemberRepository->findByTeamAndUser($team, $currentUser);
+        if (!$membership || !$membership->isCaptain()) {
+            throw ApiProblemException::forbidden('Only the team captain can register the team');
+        }
+
+        // Période d'inscription.
+        if (!$season->isRegistrationOpen()) {
+            throw ApiProblemException::badRequest('Registration is not open for this season');
+        }
+
+        // Pas de doublon.
+        $existing = $registrationRepository->findOneBy(['season' => $season, 'team' => $team]);
+        if ($existing) {
+            throw ApiProblemException::conflict('This team is already registered for this season');
+        }
+
+        // Prérequis : nombre minimum de joueurs.
+        $minPlayers = (int) $this->getParameter('app.registration.min_players');
+        $playerCount = count($playerRepository->findBy(['team' => $team]));
+        if ($playerCount < $minPlayers) {
+            throw ApiProblemException::badRequest(sprintf('Team must have at least %d players to register (currently %d)', $minPlayers, $playerCount));
+        }
+
+        $registration = new Registration();
+        $registration->setSeason($season);
+        $registration->setTeam($team);
+        $registration->setStatus(Registration::STATUS_PENDING);
+
+        $this->entityManager->persist($registration);
+        $this->entityManager->flush();
+
+        $this->logger->info('Team registered to season', ['season' => $seasonId, 'team' => $team->getId(), 'registration' => $registration->getId()]);
+
+        $response = $this->json($this->formatEntityData($registration), 201);
+        $response->headers->set('Location', '/api/registrations/' . $registration->getId());
+        return $response;
+    }
+
+    /**
+     * PATCH /api/registrations/{id}/review
+     *
+     * Un admin valide ou refuse une inscription en attente.
+     * Body : {"status": "approved"|"rejected"}.
+     */
+    #[Route('/registrations/{id}/review', name: 'app_registration_review', methods: ['PATCH'], requirements: ['id' => '\d+'])]
+    public function reviewRegistration(int $id, Request $request): JsonResponse
+    {
+        $this->checkUserRole('ROLE_ADMIN');
+
+        /** @var Registration $registration */
+        $registration = $this->findEntityOrFail(Registration::class, $id, 'Registration');
+        $data = $this->getRequestData($request);
+
+        $status = $data['status'] ?? null;
+        if (!in_array($status, [Registration::STATUS_APPROVED, Registration::STATUS_REJECTED], true)) {
+            throw ApiProblemException::badRequest('status must be "approved" or "rejected"');
+        }
+
+        $registration->setStatus($status);
+        $registration->setReviewedAt(new \DateTimeImmutable());
+        $this->entityManager->flush();
+
+        $this->logger->info('Registration reviewed', ['registration' => $id, 'status' => $status]);
+
+        return $this->json($this->formatEntityData($registration));
     }
 }

--- a/src/Controller/SeasonController.php
+++ b/src/Controller/SeasonController.php
@@ -29,7 +29,10 @@ class SeasonController extends BaseController
             'id' => $entity->getId(),
             'name' => $entity->getName(),
             'start_date' => $entity->getStartDate()->format('d-m-Y'),
-            'end_date' => $entity->getEndDate()->format('d-m-Y')
+            'end_date' => $entity->getEndDate()->format('d-m-Y'),
+            'registration_open_date' => $entity->getRegistrationOpenDate()?->format('d-m-Y'),
+            'registration_close_date' => $entity->getRegistrationCloseDate()?->format('d-m-Y'),
+            'registration_open' => $entity->isRegistrationOpen(),
         ];
     }
     /**
@@ -233,6 +236,12 @@ class SeasonController extends BaseController
         $season->setName($data['name']);
         $season->setStartDate(new \DateTime($data['start_date']));
         $season->setEndDate(new \DateTime($data['end_date']));
+        if (!empty($data['registration_open_date'])) {
+            $season->setRegistrationOpenDate(new \DateTime($data['registration_open_date']));
+        }
+        if (!empty($data['registration_close_date'])) {
+            $season->setRegistrationCloseDate(new \DateTime($data['registration_close_date']));
+        }
 
         return $this->securedCreateEntity($season, $request);
     }
@@ -245,6 +254,12 @@ class SeasonController extends BaseController
         $season->setName($data['name']);
         $season->setStartDate(new \DateTime($data['start_date']));
         $season->setEndDate(new \DateTime($data['end_date']));
+        if (array_key_exists('registration_open_date', $data)) {
+            $season->setRegistrationOpenDate($data['registration_open_date'] ? new \DateTime($data['registration_open_date']) : null);
+        }
+        if (array_key_exists('registration_close_date', $data)) {
+            $season->setRegistrationCloseDate($data['registration_close_date'] ? new \DateTime($data['registration_close_date']) : null);
+        }
 
         return $this->securedUpdateEntity($season);
     }
@@ -262,6 +277,12 @@ class SeasonController extends BaseController
         }
         if (isset($data['end_date'])) {
             $season->setEndDate(new \DateTime($data['end_date']));
+        }
+        if (array_key_exists('registration_open_date', $data)) {
+            $season->setRegistrationOpenDate($data['registration_open_date'] ? new \DateTime($data['registration_open_date']) : null);
+        }
+        if (array_key_exists('registration_close_date', $data)) {
+            $season->setRegistrationCloseDate($data['registration_close_date'] ? new \DateTime($data['registration_close_date']) : null);
         }
 
         return $this->securedUpdateEntity($season);

--- a/src/Entity/Registration.php
+++ b/src/Entity/Registration.php
@@ -8,6 +8,12 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity(repositoryClass: RegistrationRepository::class)]
 class Registration
 {
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_APPROVED = 'approved';
+    public const STATUS_REJECTED = 'rejected';
+
+    public const STATUSES = [self::STATUS_PENDING, self::STATUS_APPROVED, self::STATUS_REJECTED];
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
@@ -19,9 +25,67 @@ class Registration
     #[ORM\ManyToOne(inversedBy: 'registrations')]
     private ?Team $team = null;
 
+    #[ORM\Column(length: 20)]
+    private string $status = self::STATUS_PENDING;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $reviewedAt = null;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
     public function getId(): ?int
     {
         return $this->id;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): static
+    {
+        if (!in_array($status, self::STATUSES, true)) {
+            throw new \InvalidArgumentException('Invalid registration status: ' . $status);
+        }
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeImmutable $createdAt): static
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getReviewedAt(): ?\DateTimeImmutable
+    {
+        return $this->reviewedAt;
+    }
+
+    public function setReviewedAt(?\DateTimeImmutable $reviewedAt): static
+    {
+        $this->reviewedAt = $reviewedAt;
+
+        return $this;
+    }
+
+    public function isPending(): bool
+    {
+        return $this->status === self::STATUS_PENDING;
     }
 
     public function getSeason(): ?Season

--- a/src/Entity/Season.php
+++ b/src/Entity/Season.php
@@ -25,6 +25,12 @@ class Season
     #[ORM\Column(type: Types::DATE_MUTABLE, nullable: true)]
     private ?\DateTimeInterface $endDate = null;
 
+    #[ORM\Column(type: Types::DATE_MUTABLE, nullable: true)]
+    private ?\DateTimeInterface $registrationOpenDate = null;
+
+    #[ORM\Column(type: Types::DATE_MUTABLE, nullable: true)]
+    private ?\DateTimeInterface $registrationCloseDate = null;
+
     /**
      * @var Collection<int, Registration>
      */
@@ -75,6 +81,55 @@ class Season
         $this->endDate = $endDate;
 
         return $this;
+    }
+
+    public function getRegistrationOpenDate(): ?\DateTimeInterface
+    {
+        return $this->registrationOpenDate;
+    }
+
+    public function setRegistrationOpenDate(?\DateTimeInterface $registrationOpenDate): static
+    {
+        $this->registrationOpenDate = $registrationOpenDate;
+
+        return $this;
+    }
+
+    public function getRegistrationCloseDate(): ?\DateTimeInterface
+    {
+        return $this->registrationCloseDate;
+    }
+
+    public function setRegistrationCloseDate(?\DateTimeInterface $registrationCloseDate): static
+    {
+        $this->registrationCloseDate = $registrationCloseDate;
+
+        return $this;
+    }
+
+    /**
+     * Indique si la période d'inscription est ouverte à l'instant donné.
+     * Une borne nulle est considérée comme non contraignante :
+     * - open null  → pas de date d'ouverture (déjà ouverte)
+     * - close null → pas de date de fermeture (toujours ouverte)
+     */
+    public function isRegistrationOpen(?\DateTimeInterface $now = null): bool
+    {
+        $now = $now ?? new \DateTimeImmutable();
+
+        if ($this->registrationOpenDate !== null && $now < $this->registrationOpenDate) {
+            return false;
+        }
+
+        if ($this->registrationCloseDate !== null) {
+            // Fin de journée incluse pour la date de fermeture.
+            $closeEndOfDay = (new \DateTimeImmutable($this->registrationCloseDate->format('Y-m-d')))->setTime(23, 59, 59);
+            if ($now > $closeEndOfDay) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/EventListener/ApiSecurityListener.php
+++ b/src/EventListener/ApiSecurityListener.php
@@ -90,6 +90,11 @@ class ApiSecurityListener
             return true;
         }
 
+        // Match /api/seasons/{id}/register (inscription par le capitaine)
+        if (preg_match('#^/api/seasons/\d+/register$#', $path)) {
+            return true;
+        }
+
         return false;
     }
 }

--- a/tests/Functional/Controller/RegistrationControllerTest.php
+++ b/tests/Functional/Controller/RegistrationControllerTest.php
@@ -6,6 +6,9 @@ use App\Tests\Functional\ApiTestCase;
 use App\Entity\Registration;
 use App\Entity\Team;
 use App\Entity\Season;
+use App\Entity\Player;
+use App\Entity\TeamMember;
+use App\Entity\User;
 
 class RegistrationControllerTest extends ApiTestCase
 {
@@ -154,5 +157,188 @@ class RegistrationControllerTest extends ApiTestCase
 
         $registrationData = $response[0];
         $this->assertEquals($season->getName(), $registrationData['season']);
+    }
+
+    // ==========================================
+    // Flux d'inscription à une saison (issue api#35)
+    // ==========================================
+
+    private function makeOpenSeason(): Season
+    {
+        $season = new Season();
+        $season->setName('Saison Ouverte');
+        $season->setRegistrationOpenDate(new \DateTime('-1 week'));
+        $season->setRegistrationCloseDate(new \DateTime('+1 week'));
+        $this->entityManager->persist($season);
+        return $season;
+    }
+
+    /**
+     * Crée une équipe avec `playerCount` joueurs et un membre authentifié
+     * ayant le rôle donné. Retourne l'équipe.
+     */
+    private function makeTeamWithCaptain(string $role, int $playerCount): Team
+    {
+        $user = new User();
+        $user->setUsername('cap_' . uniqid());
+        $user->setPassword('hashed');
+        $user->setRoles(['ROLE_USER']);
+        $user->setIsActive(true);
+        $user->setDiscordId('discord_' . uniqid());
+        $this->entityManager->persist($user);
+
+        $team = new Team();
+        $team->setName('Équipe Inscription');
+        $this->entityManager->persist($team);
+
+        $member = new TeamMember();
+        $member->setUser($user);
+        $member->setRole($role);
+        $team->addMember($member);
+        $this->entityManager->persist($member);
+
+        for ($i = 0; $i < $playerCount; $i++) {
+            $player = new Player();
+            $player->setName('Joueur ' . $i);
+            $player->setTeam($team);
+            $this->entityManager->persist($player);
+        }
+
+        $this->entityManager->flush();
+        $this->client->loginUser($user, 'api');
+
+        return $team;
+    }
+
+    private function authenticateAsAdmin(): void
+    {
+        $admin = new User();
+        $admin->setUsername('admin_' . uniqid());
+        $admin->setPassword('hashed');
+        $admin->setRoles(['ROLE_USER', 'ROLE_API', 'ROLE_ADMIN']);
+        $admin->setIsActive(true);
+        $this->entityManager->persist($admin);
+        $this->entityManager->flush();
+        $this->client->loginUser($admin, 'api');
+    }
+
+    public function testCaptainCanRegisterTeam(): void
+    {
+        $season = $this->makeOpenSeason();
+        $team = $this->makeTeamWithCaptain(TeamMember::ROLE_CAPTAIN, 3);
+        $this->entityManager->flush();
+
+        $response = $this->jsonRequest('POST', '/api/seasons/' . $season->getId() . '/register', [
+            'team_id' => $team->getId(),
+        ]);
+
+        $this->assertResponseStatusCode(201);
+        $this->assertEquals('pending', $response['status']);
+        $this->assertEquals($team->getId(), $response['team_id']);
+        $this->assertEquals($season->getId(), $response['season_id']);
+    }
+
+    public function testRegisterFailsWithoutEnoughPlayers(): void
+    {
+        $season = $this->makeOpenSeason();
+        $team = $this->makeTeamWithCaptain(TeamMember::ROLE_CAPTAIN, 1);
+        $this->entityManager->flush();
+
+        $this->jsonRequest('POST', '/api/seasons/' . $season->getId() . '/register', [
+            'team_id' => $team->getId(),
+        ]);
+
+        $this->assertResponseStatusCode(400);
+    }
+
+    public function testNonCaptainCannotRegister(): void
+    {
+        $season = $this->makeOpenSeason();
+        $team = $this->makeTeamWithCaptain(TeamMember::ROLE_MEMBER, 3);
+        $this->entityManager->flush();
+
+        $this->jsonRequest('POST', '/api/seasons/' . $season->getId() . '/register', [
+            'team_id' => $team->getId(),
+        ]);
+
+        $this->assertResponseStatusCode(403);
+    }
+
+    public function testRegisterFailsWhenWindowClosed(): void
+    {
+        $season = new Season();
+        $season->setName('Saison Fermée');
+        $season->setRegistrationOpenDate(new \DateTime('-3 weeks'));
+        $season->setRegistrationCloseDate(new \DateTime('-1 week'));
+        $this->entityManager->persist($season);
+
+        $team = $this->makeTeamWithCaptain(TeamMember::ROLE_CAPTAIN, 3);
+        $this->entityManager->flush();
+
+        $this->jsonRequest('POST', '/api/seasons/' . $season->getId() . '/register', [
+            'team_id' => $team->getId(),
+        ]);
+
+        $this->assertResponseStatusCode(400);
+    }
+
+    public function testDuplicateRegistrationRejected(): void
+    {
+        $season = $this->makeOpenSeason();
+        $team = $this->makeTeamWithCaptain(TeamMember::ROLE_CAPTAIN, 3);
+        $this->entityManager->flush();
+
+        $uri = '/api/seasons/' . $season->getId() . '/register';
+        $this->jsonRequest('POST', $uri, ['team_id' => $team->getId()]);
+        $this->assertResponseStatusCode(201);
+
+        $this->jsonRequest('POST', $uri, ['team_id' => $team->getId()]);
+        $this->assertResponseStatusCode(409);
+    }
+
+    public function testAdminCanApproveRegistration(): void
+    {
+        $season = $this->makeOpenSeason();
+        $team = new Team();
+        $team->setName('Équipe À Valider');
+        $this->entityManager->persist($team);
+
+        $registration = new Registration();
+        $registration->setSeason($season);
+        $registration->setTeam($team);
+        $this->entityManager->persist($registration);
+        $this->entityManager->flush();
+
+        $this->authenticateAsAdmin();
+
+        $response = $this->jsonRequest('PATCH', '/api/registrations/' . $registration->getId() . '/review', [
+            'status' => 'approved',
+        ]);
+
+        $this->assertResponseStatusCode(200);
+        $this->assertEquals('approved', $response['status']);
+        $this->assertNotNull($response['reviewed_at']);
+    }
+
+    public function testReviewRejectsInvalidStatus(): void
+    {
+        $season = $this->makeOpenSeason();
+        $team = new Team();
+        $team->setName('Équipe X');
+        $this->entityManager->persist($team);
+
+        $registration = new Registration();
+        $registration->setSeason($season);
+        $registration->setTeam($team);
+        $this->entityManager->persist($registration);
+        $this->entityManager->flush();
+
+        $this->authenticateAsAdmin();
+
+        $this->jsonRequest('PATCH', '/api/registrations/' . $registration->getId() . '/review', [
+            'status' => 'maybe',
+        ]);
+
+        $this->assertResponseStatusCode(400);
     }
 }

--- a/tests/Functional/Controller/RegistrationControllerTest.php
+++ b/tests/Functional/Controller/RegistrationControllerTest.php
@@ -286,13 +286,17 @@ class RegistrationControllerTest extends ApiTestCase
     {
         $season = $this->makeOpenSeason();
         $team = $this->makeTeamWithCaptain(TeamMember::ROLE_CAPTAIN, 3);
+
+        // Inscription déjà existante en base.
+        $existing = new Registration();
+        $existing->setSeason($season);
+        $existing->setTeam($team);
+        $this->entityManager->persist($existing);
         $this->entityManager->flush();
 
-        $uri = '/api/seasons/' . $season->getId() . '/register';
-        $this->jsonRequest('POST', $uri, ['team_id' => $team->getId()]);
-        $this->assertResponseStatusCode(201);
-
-        $this->jsonRequest('POST', $uri, ['team_id' => $team->getId()]);
+        $this->jsonRequest('POST', '/api/seasons/' . $season->getId() . '/register', [
+            'team_id' => $team->getId(),
+        ]);
         $this->assertResponseStatusCode(409);
     }
 


### PR DESCRIPTION
Résout **#35**.

## Fonctionnalités
- [x] Une équipe (via son capitaine) peut s'inscrire à une saison ouverte
- [x] Les admins peuvent valider ou refuser une inscription
- [x] Période d'inscription configurable (dates d'ouverture/fermeture sur la saison)
- [x] Vérification des prérequis (nombre minimum de joueurs, configurable)
- [x] S'appuie sur l'entité `Registration` existante

## Détails
**Entités**
- `Registration` : `status` (`pending`/`approved`/`rejected`), `createdAt`, `reviewedAt`
- `Season` : `registrationOpenDate` / `registrationCloseDate` + `isRegistrationOpen()` (bornes nulles = non contraignantes)

**Endpoints**
- `POST /api/seasons/{id}/register` (ROLE_USER, capitaine de l'équipe) — crée une inscription `pending` ; contrôles : capitaine, fenêtre ouverte, pas de doublon, minimum de joueurs
- `PATCH /api/registrations/{id}/review` (ROLE_ADMIN) — `{status: approved|rejected}`
- `SeasonController` (POST/PUT/PATCH) accepte désormais `registration_open_date` / `registration_close_date`

**Config** : `REGISTRATION_MIN_PLAYERS` (défaut `3`) via `.env` / paramètre `app.registration.min_players`.

**Migration** : `Version20260723120000` (PostgreSQL). Les tests utilisent le SchemaTool (schéma auto depuis les entités).

## Tests
Inscription capitaine (201), joueurs insuffisants (400), non-capitaine (403), fenêtre fermée (400), doublon (409), validation admin (200), statut invalide (400).

> ⚠️ Base = `feat/backend-v2-integrated` (dépend de `TeamMember`, non encore sur `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)