### PR TITLE
feat(divisions): promotion/relégation entre divisions (#36)

### DIFF
--- a/migrations/Version20260723130000.php
+++ b/migrations/Version20260723130000.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Hiérarchie des divisions pour la promotion/relégation (issue api#36) :
+ * niveau + nombres de montées/descentes par division.
+ */
+final class Version20260723130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add division hierarchy (level, promotion_count, relegation_count)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE division ADD level INT NOT NULL DEFAULT 1');
+        $this->addSql('ALTER TABLE division ADD promotion_count INT NOT NULL DEFAULT 0');
+        $this->addSql('ALTER TABLE division ADD relegation_count INT NOT NULL DEFAULT 0');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE division DROP level');
+        $this->addSql('ALTER TABLE division DROP promotion_count');
+        $this->addSql('ALTER TABLE division DROP relegation_count');
+    }
+}

--- a/src/Controller/DivisionController.php
+++ b/src/Controller/DivisionController.php
@@ -10,6 +10,9 @@ use App\Repository\SeasonRepository;
 use App\Repository\GameStatusRepository;
 use App\Service\PushNotificationService;
 use App\Service\TeamStatCalculatorService;
+use App\Service\SeasonPromotionService;
+use App\Entity\Team;
+use App\Entity\TeamStat;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Attribute\Route;
@@ -42,6 +45,9 @@ class DivisionController extends BaseController
                 ? $entity->getSeason()->getName()
                 : "",
             "is_finalized" => $entity->isFinalized(),
+            "level" => $entity->getLevel(),
+            "promotion_count" => $entity->getPromotionCount(),
+            "relegation_count" => $entity->getRelegationCount(),
         ];
     }
 
@@ -328,6 +334,8 @@ class DivisionController extends BaseController
             $division->setSeason(null);
         }
 
+        $this->applyHierarchyFields($division, $data);
+
         return $this->securedCreateEntity($division, $request);
     }
 
@@ -351,6 +359,8 @@ class DivisionController extends BaseController
             );
             $division->setSeason($season);
         }
+
+        $this->applyHierarchyFields($division, $data);
 
         return $this->securedUpdateEntity($division);
     }
@@ -380,6 +390,8 @@ class DivisionController extends BaseController
             );
             $division->setSeason($season);
         }
+
+        $this->applyHierarchyFields($division, $data);
 
         $shouldNotify = isset($data["is_finalized"])
             && $data["is_finalized"] === true
@@ -417,6 +429,156 @@ class DivisionController extends BaseController
         }
 
         return $response;
+    }
+
+    /**
+     * Applique les champs de hiérarchie (niveau, promotions, relégations)
+     * présents dans les données de requête à une division.
+     */
+    private function applyHierarchyFields(Division $division, array $data): void
+    {
+        if (isset($data["level"])) {
+            $division->setLevel((int) $data["level"]);
+        }
+        if (isset($data["promotion_count"])) {
+            $division->setPromotionCount((int) $data["promotion_count"]);
+        }
+        if (isset($data["relegation_count"])) {
+            $division->setRelegationCount((int) $data["relegation_count"]);
+        }
+    }
+
+    // ==========================================
+    // Promotion / relégation (issue api#36)
+    // ==========================================
+
+    /**
+     * GET /api/seasons/{seasonId}/promotion-preview
+     *
+     * Prévisualise (sans rien modifier) les mouvements de promotion/relégation
+     * calculés à partir des classements finaux. Réservé aux admins.
+     */
+    #[Route("/seasons/{seasonId}/promotion-preview", name: "app_season_promotion_preview", methods: ["GET"], requirements: ["seasonId" => "\d+"])]
+    public function promotionPreview(int $seasonId, SeasonPromotionService $promotionService): JsonResponse
+    {
+        $this->checkUserRole('ROLE_ADMIN');
+
+        /** @var Season $season */
+        $season = $this->findEntityOrFail(Season::class, $seasonId, 'Season');
+
+        return $this->json([
+            'season_id' => $season->getId(),
+            'season_name' => $season->getName(),
+            'divisions' => $promotionService->computeMovements($season),
+        ]);
+    }
+
+    /**
+     * POST /api/seasons/{seasonId}/apply-promotions
+     *
+     * Applique les mouvements calculés à une saison cible en créant les
+     * TeamStat (0-initialisées) et Registration (approuvées) des équipes dans
+     * la division du niveau cible. Les ajustements manuels sont possibles via
+     * `adjustments: [{team_id, to_level}]`. Réservé aux admins.
+     */
+    #[Route("/seasons/{seasonId}/apply-promotions", name: "app_season_apply_promotions", methods: ["POST"], requirements: ["seasonId" => "\d+"])]
+    public function applyPromotions(
+        int $seasonId,
+        Request $request,
+        SeasonPromotionService $promotionService,
+        DivisionRepository $divisionRepository,
+        TeamStatRepository $teamStatRepository,
+        \App\Repository\RegistrationRepository $registrationRepository,
+    ): JsonResponse {
+        $this->checkUserRole('ROLE_ADMIN');
+
+        /** @var Season $sourceSeason */
+        $sourceSeason = $this->findEntityOrFail(Season::class, $seasonId, 'Season');
+
+        $data = $this->getRequestData($request);
+        $targetSeasonId = $data['target_season_id'] ?? null;
+        if (!$targetSeasonId) {
+            throw ApiProblemException::validationError('target_season_id is required', [['field' => 'target_season_id', 'message' => 'This value should not be blank.']]);
+        }
+
+        /** @var Season $targetSeason */
+        $targetSeason = $this->findEntityOrFail(Season::class, $targetSeasonId, 'Season');
+
+        // Niveaux cibles calculés, puis surchargés par les ajustements manuels.
+        $movements = $promotionService->computeMovements($sourceSeason);
+        $targetLevels = $promotionService->flattenTargetLevels($movements);
+
+        foreach (($data['adjustments'] ?? []) as $adjustment) {
+            if (isset($adjustment['team_id'], $adjustment['to_level'])) {
+                $targetLevels[(int) $adjustment['team_id']] = (int) $adjustment['to_level'];
+            }
+        }
+
+        // Indexe les divisions de la saison cible par niveau.
+        $targetDivisionsByLevel = [];
+        foreach ($divisionRepository->findBy(['season' => $targetSeason]) as $division) {
+            $targetDivisionsByLevel[$division->getLevel()] = $division;
+        }
+
+        $applied = [];
+        $skipped = [];
+
+        foreach ($targetLevels as $teamId => $toLevel) {
+            $division = $targetDivisionsByLevel[$toLevel] ?? null;
+            if ($division === null) {
+                $skipped[] = ['team_id' => $teamId, 'reason' => 'no target division at level ' . $toLevel];
+                continue;
+            }
+
+            /** @var Team|null $team */
+            $team = $this->entityManager->getRepository(Team::class)->find($teamId);
+            if ($team === null) {
+                $skipped[] = ['team_id' => $teamId, 'reason' => 'team not found'];
+                continue;
+            }
+
+            // Inscription à la saison cible (si absente).
+            $existingRegistration = $registrationRepository->findOneBy(['season' => $targetSeason, 'team' => $team]);
+            if ($existingRegistration === null) {
+                $registration = new \App\Entity\Registration();
+                $registration->setSeason($targetSeason);
+                $registration->setTeam($team);
+                $this->entityManager->persist($registration);
+            }
+
+            // TeamStat 0-initialisée dans la division cible (si absente).
+            $existingStat = $teamStatRepository->findOneBy(['team' => $team, 'division' => $division]);
+            if ($existingStat === null) {
+                $stat = new TeamStat();
+                $stat->setTeam($team);
+                $stat->setDivision($division);
+                $stat->setWins(0);
+                $stat->setLosses(0);
+                $stat->setTies(0);
+                $stat->setPoints(0);
+                $stat->setWinRounds(0);
+                $stat->setLooseRounds(0);
+                $this->entityManager->persist($stat);
+            }
+
+            $applied[] = ['team_id' => $teamId, 'to_level' => $toLevel, 'division_id' => $division->getId()];
+        }
+
+        $this->entityManager->flush();
+
+        $this->logger->info('Promotions applied', [
+            'source_season' => $seasonId,
+            'target_season' => $targetSeason->getId(),
+            'applied' => count($applied),
+            'skipped' => count($skipped),
+        ]);
+
+        return $this->json([
+            'source_season_id' => $sourceSeason->getId(),
+            'target_season_id' => $targetSeason->getId(),
+            'applied' => $applied,
+            'skipped' => $skipped,
+        ]);
     }
 
     #[Route("/divisions/{id}", name: "app_division_delete", methods: ["DELETE"], requirements: ["id" => "\d+"])]

--- a/src/Controller/DivisionController.php
+++ b/src/Controller/DivisionController.php
@@ -461,6 +461,14 @@ class DivisionController extends BaseController
     #[Route("/seasons/{seasonId}/promotion-preview", name: "app_season_promotion_preview", methods: ["GET"], requirements: ["seasonId" => "\d+"])]
     public function promotionPreview(int $seasonId, SeasonPromotionService $promotionService): JsonResponse
     {
+        // Ce endpoint GET est en PUBLIC_ACCESS au niveau du firewall : un
+        // anonyme atteint donc le contrôleur. On convertit l'absence
+        // d'authentification en 401 propre avant la vérification du rôle.
+        try {
+            $this->getAuthenticatedUser();
+        } catch (\Symfony\Component\Security\Core\Exception\AccessDeniedException $e) {
+            throw ApiProblemException::unauthorized($e->getMessage());
+        }
         $this->checkUserRole('ROLE_ADMIN');
 
         /** @var Season $season */

--- a/src/Entity/Division.php
+++ b/src/Entity/Division.php
@@ -22,6 +22,22 @@ class Division
     #[ORM\Column(type: 'boolean', options: ['default' => false])]
     private bool $isFinalized = false;
 
+    /**
+     * Niveau hiérarchique de la division (1 = division la plus haute).
+     * Utilisé pour la promotion (vers un niveau inférieur en nombre) et la
+     * relégation (vers un niveau supérieur en nombre).
+     */
+    #[ORM\Column(type: 'integer', options: ['default' => 1])]
+    private int $level = 1;
+
+    /** Nombre d'équipes promues depuis cette division en fin de saison. */
+    #[ORM\Column(type: 'integer', options: ['default' => 0])]
+    private int $promotionCount = 0;
+
+    /** Nombre d'équipes reléguées depuis cette division en fin de saison. */
+    #[ORM\Column(type: 'integer', options: ['default' => 0])]
+    private int $relegationCount = 0;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -59,6 +75,42 @@ class Division
     public function setIsFinalized(bool $isFinalized): static
     {
         $this->isFinalized = $isFinalized;
+
+        return $this;
+    }
+
+    public function getLevel(): int
+    {
+        return $this->level;
+    }
+
+    public function setLevel(int $level): static
+    {
+        $this->level = max(1, $level);
+
+        return $this;
+    }
+
+    public function getPromotionCount(): int
+    {
+        return $this->promotionCount;
+    }
+
+    public function setPromotionCount(int $promotionCount): static
+    {
+        $this->promotionCount = max(0, $promotionCount);
+
+        return $this;
+    }
+
+    public function getRelegationCount(): int
+    {
+        return $this->relegationCount;
+    }
+
+    public function setRelegationCount(int $relegationCount): static
+    {
+        $this->relegationCount = max(0, $relegationCount);
 
         return $this;
     }

--- a/src/Service/SeasonPromotionService.php
+++ b/src/Service/SeasonPromotionService.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Division;
+use App\Entity\Season;
+use App\Entity\TeamStat;
+use App\Repository\DivisionRepository;
+use App\Repository\TeamStatRepository;
+
+/**
+ * Calcule les mouvements de promotion / relégation entre divisions d'une saison
+ * à partir des classements finaux (issue api#36).
+ *
+ * Convention de niveau : 1 = division la plus haute. Une équipe promue passe au
+ * niveau immédiatement inférieur en nombre (level - 1), une équipe reléguée au
+ * niveau immédiatement supérieur en nombre (level + 1).
+ */
+class SeasonPromotionService
+{
+    public function __construct(
+        private DivisionRepository $divisionRepository,
+        private TeamStatRepository $teamStatRepository,
+    ) {
+    }
+
+    /**
+     * Trie un tableau de TeamStat par classement :
+     * points desc, puis différence de rounds desc, puis rounds gagnés desc.
+     *
+     * @param TeamStat[] $teamStats
+     * @return TeamStat[]
+     */
+    private function sortStandings(array $teamStats): array
+    {
+        usort($teamStats, function (TeamStat $a, TeamStat $b) {
+            if ($a->getPoints() !== $b->getPoints()) {
+                return $b->getPoints() <=> $a->getPoints();
+            }
+            $diffA = $a->getWinRounds() - $a->getLooseRounds();
+            $diffB = $b->getWinRounds() - $b->getLooseRounds();
+            if ($diffA !== $diffB) {
+                return $diffB <=> $diffA;
+            }
+            return $b->getWinRounds() <=> $a->getWinRounds();
+        });
+
+        return $teamStats;
+    }
+
+    /**
+     * Calcule les mouvements pour toutes les divisions d'une saison.
+     *
+     * @return array<int, array<string, mixed>> Une entrée par division, triée par niveau.
+     */
+    public function computeMovements(Season $season): array
+    {
+        $divisions = $this->divisionRepository->findBy(['season' => $season]);
+
+        if (empty($divisions)) {
+            return [];
+        }
+
+        $levels = array_map(fn (Division $d) => $d->getLevel(), $divisions);
+        $minLevel = min($levels);
+        $maxLevel = max($levels);
+
+        usort($divisions, fn (Division $a, Division $b) => $a->getLevel() <=> $b->getLevel());
+
+        $result = [];
+        foreach ($divisions as $division) {
+            $standings = $this->sortStandings(
+                $this->teamStatRepository->findBy(['division' => $division])
+            );
+            $count = count($standings);
+            $level = $division->getLevel();
+
+            // On ne peut pas promouvoir depuis la division la plus haute,
+            // ni reléguer depuis la plus basse.
+            $promoteN = $level > $minLevel ? min($division->getPromotionCount(), $count) : 0;
+            $relegateN = $level < $maxLevel ? min($division->getRelegationCount(), $count) : 0;
+
+            // Si la division est trop petite pour promouvoir ET reléguer autant,
+            // on rogne d'abord la relégation.
+            if ($promoteN + $relegateN > $count) {
+                $relegateN = max(0, $count - $promoteN);
+            }
+
+            $promoted = [];
+            $relegated = [];
+            $stayed = [];
+
+            foreach ($standings as $i => $stat) {
+                $team = $stat->getTeam();
+                $entry = [
+                    'team_id' => $team->getId(),
+                    'team_name' => $team->getName(),
+                    'rank' => $i + 1,
+                    'points' => $stat->getPoints(),
+                    'from_level' => $level,
+                ];
+
+                if ($i < $promoteN) {
+                    $entry['to_level'] = $level - 1;
+                    $entry['movement'] = 'promoted';
+                    $promoted[] = $entry;
+                } elseif ($i >= $count - $relegateN) {
+                    $entry['to_level'] = $level + 1;
+                    $entry['movement'] = 'relegated';
+                    $relegated[] = $entry;
+                } else {
+                    $entry['to_level'] = $level;
+                    $entry['movement'] = 'stayed';
+                    $stayed[] = $entry;
+                }
+            }
+
+            $result[] = [
+                'division_id' => $division->getId(),
+                'division_name' => $division->getName(),
+                'level' => $level,
+                'promotion_count' => $promoteN,
+                'relegation_count' => $relegateN,
+                'promoted' => $promoted,
+                'relegated' => $relegated,
+                'stayed' => $stayed,
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Aplati les mouvements calculés en une liste team_id => to_level.
+     *
+     * @param array<int, array<string, mixed>> $movements
+     * @return array<int, int> team_id => niveau cible
+     */
+    public function flattenTargetLevels(array $movements): array
+    {
+        $map = [];
+        foreach ($movements as $divisionMovement) {
+            foreach (['promoted', 'relegated', 'stayed'] as $bucket) {
+                foreach ($divisionMovement[$bucket] as $entry) {
+                    $map[$entry['team_id']] = $entry['to_level'];
+                }
+            }
+        }
+
+        return $map;
+    }
+}

--- a/tests/Functional/Controller/DivisionPromotionControllerTest.php
+++ b/tests/Functional/Controller/DivisionPromotionControllerTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use App\Tests\Functional\ApiTestCase;
+use App\Entity\Season;
+use App\Entity\Division;
+use App\Entity\Team;
+use App\Entity\TeamStat;
+use App\Entity\User;
+
+/**
+ * Tests du flux de promotion/relégation (issue api#36).
+ */
+class DivisionPromotionControllerTest extends ApiTestCase
+{
+    private function authenticateAsAdmin(): void
+    {
+        $admin = new User();
+        $admin->setUsername('admin_' . uniqid());
+        $admin->setPassword('hashed');
+        $admin->setRoles(['ROLE_USER', 'ROLE_API', 'ROLE_ADMIN']);
+        $admin->setIsActive(true);
+        $this->entityManager->persist($admin);
+        $this->entityManager->flush();
+        $this->client->loginUser($admin, 'api');
+    }
+
+    private function makeDivision(Season $season, string $name, int $level, int $promo, int $releg): Division
+    {
+        $division = new Division();
+        $division->setName($name);
+        $division->setSeason($season);
+        $division->setLevel($level);
+        $division->setPromotionCount($promo);
+        $division->setRelegationCount($releg);
+        $this->entityManager->persist($division);
+        return $division;
+    }
+
+    private function makeTeamStat(Division $division, string $teamName, int $points): Team
+    {
+        $team = new Team();
+        $team->setName($teamName);
+        $this->entityManager->persist($team);
+
+        $stat = new TeamStat();
+        $stat->setTeam($team);
+        $stat->setDivision($division);
+        $stat->setWins($points > 0 ? $points : 0);
+        $stat->setLosses(0);
+        $stat->setTies(0);
+        $stat->setPoints($points);
+        $stat->setWinRounds($points);
+        $stat->setLooseRounds(0);
+        $this->entityManager->persist($stat);
+
+        return $team;
+    }
+
+    public function testPromotionPreviewComputesMovements(): void
+    {
+        $season = new Season();
+        $season->setName('Saison Source');
+        $this->entityManager->persist($season);
+
+        $d1 = $this->makeDivision($season, 'Division 1', 1, 0, 1);
+        $d2 = $this->makeDivision($season, 'Division 2', 2, 1, 0);
+
+        $teamA = $this->makeTeamStat($d1, 'Team A', 6);
+        $teamB = $this->makeTeamStat($d1, 'Team B', 3);
+        $teamC = $this->makeTeamStat($d2, 'Team C', 6);
+        $teamD = $this->makeTeamStat($d2, 'Team D', 3);
+
+        $this->entityManager->flush();
+
+        $this->authenticateAsAdmin();
+
+        $response = $this->jsonRequest('GET', '/api/seasons/' . $season->getId() . '/promotion-preview');
+        $this->assertResponseStatusCode(200);
+
+        $byLevel = [];
+        foreach ($response['divisions'] as $div) {
+            $byLevel[$div['level']] = $div;
+        }
+
+        // Division niveau 1 (la plus haute) : aucune promotion, Team B (dernier) relégué.
+        $this->assertCount(0, $byLevel[1]['promoted']);
+        $this->assertCount(1, $byLevel[1]['relegated']);
+        $this->assertEquals($teamB->getId(), $byLevel[1]['relegated'][0]['team_id']);
+        $this->assertEquals(2, $byLevel[1]['relegated'][0]['to_level']);
+
+        // Division niveau 2 : Team C (premier) promu, Team D maintenu.
+        $this->assertCount(1, $byLevel[2]['promoted']);
+        $this->assertEquals($teamC->getId(), $byLevel[2]['promoted'][0]['team_id']);
+        $this->assertEquals(1, $byLevel[2]['promoted'][0]['to_level']);
+        $this->assertCount(0, $byLevel[2]['relegated']);
+    }
+
+    public function testPromotionPreviewRequiresAdmin(): void
+    {
+        $season = new Season();
+        $season->setName('Saison X');
+        $this->entityManager->persist($season);
+        $this->entityManager->flush();
+
+        // Non authentifié → refus.
+        $this->jsonRequest('GET', '/api/seasons/' . $season->getId() . '/promotion-preview');
+        $this->assertContains($this->client->getResponse()->getStatusCode(), [401, 403]);
+    }
+
+    public function testApplyPromotionsToTargetSeason(): void
+    {
+        $source = new Season();
+        $source->setName('Saison Source');
+        $this->entityManager->persist($source);
+
+        $d1 = $this->makeDivision($source, 'Division 1', 1, 0, 1);
+        $d2 = $this->makeDivision($source, 'Division 2', 2, 1, 0);
+
+        $teamA = $this->makeTeamStat($d1, 'Team A', 6);
+        $teamB = $this->makeTeamStat($d1, 'Team B', 3);
+        $teamC = $this->makeTeamStat($d2, 'Team C', 6);
+        $teamD = $this->makeTeamStat($d2, 'Team D', 3);
+
+        // Saison cible avec les mêmes niveaux.
+        $target = new Season();
+        $target->setName('Saison Cible');
+        $this->entityManager->persist($target);
+        $t1 = $this->makeDivision($target, 'Division 1 (N+1)', 1, 0, 1);
+        $t2 = $this->makeDivision($target, 'Division 2 (N+1)', 2, 1, 0);
+
+        $this->entityManager->flush();
+
+        $this->authenticateAsAdmin();
+
+        $response = $this->jsonRequest('POST', '/api/seasons/' . $source->getId() . '/apply-promotions', [
+            'target_season_id' => $target->getId(),
+        ]);
+
+        $this->assertResponseStatusCode(200);
+        // 4 équipes placées.
+        $this->assertCount(4, $response['applied']);
+        $this->assertCount(0, $response['skipped']);
+
+        // Team B (relégué) doit se retrouver au niveau 2 de la saison cible.
+        $stat = $this->entityManager->getRepository(TeamStat::class)->findOneBy(['team' => $teamB, 'division' => $t2]);
+        $this->assertNotNull($stat);
+        $this->assertEquals(0, $stat->getPoints());
+
+        // Team C (promu) doit se retrouver au niveau 1 de la saison cible.
+        $statC = $this->entityManager->getRepository(TeamStat::class)->findOneBy(['team' => $teamC, 'division' => $t1]);
+        $this->assertNotNull($statC);
+    }
+
+    public function testApplyPromotionsRequiresTargetSeason(): void
+    {
+        $source = new Season();
+        $source->setName('Saison Source');
+        $this->entityManager->persist($source);
+        $this->entityManager->flush();
+
+        $this->authenticateAsAdmin();
+
+        $this->jsonRequest('POST', '/api/seasons/' . $source->getId() . '/apply-promotions', []);
+        $this->assertResponseStatusCode(400);
+    }
+}


### PR DESCRIPTION
Résout **#36**.

## Fonctionnalités
- [x] Règles de promotion/relégation par division (nombre de montées/descentes)
- [x] Calcul automatique des mouvements depuis le classement final
- [x] Ajustement manuel possible par les admins
- [x] Application lors de la création de la nouvelle saison

## Détails
**Entité `Division`** : `level` (1 = plus haute), `promotionCount`, `relegationCount`. Exposés et modifiables via `DivisionController` (POST/PUT/PATCH : `level`, `promotion_count`, `relegation_count`).

**`SeasonPromotionService`** : calcule, par division, les équipes promues / reléguées / maintenues à partir des classements (tri points → diff de rounds → rounds gagnés). Pas de promotion depuis le niveau le plus haut, ni de relégation depuis le plus bas ; rognage si la division est trop petite.

**Endpoints (admin)**
- `GET /api/seasons/{id}/promotion-preview` — prévisualisation sans effet de bord
- `POST /api/seasons/{id}/apply-promotions` — `{target_season_id, adjustments?: [{team_id, to_level}]}` : place chaque équipe dans la division du niveau cible de la saison suivante (crée `TeamStat` 0-initialisée + `Registration`), en signalant les équipes non placées (`skipped`)

**Migration** : `Version20260723130000` (PostgreSQL).

## Tests
`DivisionPromotionControllerTest` : calcul du preview (promu/relégué/maintenu + niveaux cibles), garde admin, application vers une saison cible, `target_season_id` requis.

> ⚠️ Base = `feat/backend-v2-integrated` (dépend de `TeamMember`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)