### PR TITLE
feat(transfers): sous-système de transferts de joueurs (#28)

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -77,6 +77,8 @@ security:
         - { path: ^/api/teams/\d+/players, roles: ROLE_USER }
         # Season registration by team captains — ROLE_USER, not ROLE_API
         - { path: ^/api/seasons/\d+/register, roles: ROLE_USER }
+        # Player transfers by destination team captains — ROLE_USER, not ROLE_API
+        - { path: ^/api/teams/\d+/transfers, roles: ROLE_USER, methods: [POST] }
         # Push subscription endpoints accessible to any authenticated user (ROLE_USER, not ROLE_API)
         - { path: ^/api/push/subscribe, roles: ROLE_USER }
         - { path: ^/api, roles: ROLE_API, methods: [POST, PUT, PATCH, DELETE] }

--- a/migrations/Version20260723140000.php
+++ b/migrations/Version20260723140000.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Table des transferts de joueurs entre équipes (issue app#28).
+ */
+final class Version20260723140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create transfer table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE transfer (
+                id SERIAL PRIMARY KEY,
+                player_id INT NOT NULL,
+                from_team_id INT DEFAULT NULL,
+                to_team_id INT NOT NULL,
+                season_id INT NOT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                CONSTRAINT FK_transfer_player FOREIGN KEY (player_id) REFERENCES player (id) ON DELETE CASCADE,
+                CONSTRAINT FK_transfer_from_team FOREIGN KEY (from_team_id) REFERENCES team (id) ON DELETE SET NULL,
+                CONSTRAINT FK_transfer_to_team FOREIGN KEY (to_team_id) REFERENCES team (id) ON DELETE CASCADE,
+                CONSTRAINT FK_transfer_season FOREIGN KEY (season_id) REFERENCES season (id) ON DELETE CASCADE
+            )
+        SQL);
+        $this->addSql('CREATE INDEX IDX_transfer_player ON transfer (player_id)');
+        $this->addSql('CREATE INDEX IDX_transfer_from_team ON transfer (from_team_id)');
+        $this->addSql('CREATE INDEX IDX_transfer_to_team ON transfer (to_team_id)');
+        $this->addSql('CREATE INDEX IDX_transfer_season ON transfer (season_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE transfer');
+    }
+}

--- a/src/Controller/TransferController.php
+++ b/src/Controller/TransferController.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Player;
+use App\Entity\Season;
+use App\Entity\Team;
+use App\Entity\Transfer;
+use App\Exception\ApiProblemException;
+use App\Repository\SeasonRepository;
+use App\Repository\TeamStatRepository;
+use App\Repository\TransferRepository;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Transferts de joueurs entre équipes (issue app#28).
+ *
+ * Règles :
+ * - 2 transferts entrants maximum par équipe et par saison ;
+ * - transfert autorisé si le niveau de division du joueur (division de son
+ *   équipe d'origine) est <= niveau de division de l'équipe d'accueil + 1.
+ *   Rappel : level 1 = division la plus haute.
+ */
+#[Route('/api')]
+class TransferController extends BaseController
+{
+    public const MAX_TRANSFERS_PER_SEASON = 2;
+
+    protected function formatEntityData($entity): array
+    {
+        if (!$entity instanceof Transfer) {
+            throw new \InvalidArgumentException('Entity must be an instance of Transfer');
+        }
+
+        return [
+            'id' => $entity->getId(),
+            'player_id' => $entity->getPlayer()?->getId(),
+            'player_name' => $entity->getPlayer()?->getName(),
+            'from_team_id' => $entity->getFromTeam()?->getId(),
+            'from_team_name' => $entity->getFromTeam()?->getName(),
+            'to_team_id' => $entity->getToTeam()?->getId(),
+            'to_team_name' => $entity->getToTeam()?->getName(),
+            'season_id' => $entity->getSeason()?->getId(),
+            'season_name' => $entity->getSeason()?->getName(),
+            'created_at' => $entity->getCreatedAt()->format('Y-m-d H:i:s'),
+        ];
+    }
+
+    /**
+     * GET /api/teams/{teamId}/transfers[?season_id=]
+     * Liste les transferts entrants d'une équipe (lecture publique).
+     */
+    #[Route('/teams/{teamId}/transfers', name: 'app_team_transfers_list', methods: ['GET'], requirements: ['teamId' => '\d+'])]
+    public function listTransfers(int $teamId, Request $request, TransferRepository $transferRepository): JsonResponse
+    {
+        /** @var Team $team */
+        $team = $this->findEntityOrFail(Team::class, $teamId, 'Team');
+
+        $seasonId = $request->query->get('season_id');
+        if ($seasonId) {
+            $season = $this->findEntityOrFail(Season::class, $seasonId, 'Season');
+            $transfers = $transferRepository->findByToTeamAndSeason($team, $season);
+        } else {
+            $transfers = $transferRepository->findBy(['toTeam' => $team], ['createdAt' => 'DESC']);
+        }
+
+        return $this->json(array_map(fn (Transfer $t) => $this->formatEntityData($t), $transfers));
+    }
+
+    /**
+     * POST /api/teams/{teamId}/transfers
+     * Body : {"player_id": <id>, "season_id"?: <id>}
+     *
+     * Le capitaine de l'équipe d'accueil (ou un admin) transfère un joueur
+     * dans son équipe. Applique les deux règles métier.
+     */
+    #[Route('/teams/{teamId}/transfers', name: 'app_team_transfer_create', methods: ['POST'], requirements: ['teamId' => '\d+'])]
+    public function createTransfer(
+        int $teamId,
+        Request $request,
+        TransferRepository $transferRepository,
+        TeamStatRepository $teamStatRepository,
+        SeasonRepository $seasonRepository
+    ): JsonResponse {
+        try {
+            $currentUser = $this->getAuthenticatedUser();
+        } catch (\Symfony\Component\Security\Core\Exception\AccessDeniedException $e) {
+            throw ApiProblemException::unauthorized($e->getMessage());
+        }
+
+        /** @var Team $toTeam */
+        $toTeam = $this->findEntityOrFail(Team::class, $teamId, 'Team');
+
+        $isAdmin = $this->authService->userHasRole($currentUser, 'ROLE_ADMIN');
+        if (!$isAdmin && !$toTeam->isCaptain($currentUser)) {
+            throw ApiProblemException::forbidden('Only the destination team captain or an admin can register a transfer');
+        }
+
+        $data = $this->getRequestData($request);
+        $playerId = $data['player_id'] ?? null;
+        if (!$playerId) {
+            throw ApiProblemException::validationError('player_id is required', [['field' => 'player_id', 'message' => 'This value should not be blank.']]);
+        }
+
+        /** @var Player $player */
+        $player = $this->findEntityOrFail(Player::class, $playerId, 'Player');
+
+        // Saison : depuis le corps, sinon la saison courante.
+        if (isset($data['season_id'])) {
+            /** @var Season $season */
+            $season = $this->findEntityOrFail(Season::class, $data['season_id'], 'Season');
+        } else {
+            $season = $seasonRepository->findCurrent(new \DateTime());
+            if (!$season) {
+                throw ApiProblemException::badRequest('No season_id provided and no current season found');
+            }
+        }
+
+        $fromTeam = $player->getTeam();
+
+        if ($fromTeam && $fromTeam->getId() === $toTeam->getId()) {
+            throw ApiProblemException::badRequest('Player already belongs to this team');
+        }
+
+        // Règle 1 : maximum de transferts entrants par saison.
+        $count = $transferRepository->countByToTeamAndSeason($toTeam, $season);
+        if ($count >= self::MAX_TRANSFERS_PER_SEASON) {
+            throw ApiProblemException::badRequest(sprintf(
+                'This team has reached the maximum number of transfers for this season (%d)',
+                self::MAX_TRANSFERS_PER_SEASON
+            ));
+        }
+
+        // Règle 2 : niveau du joueur <= niveau de l'équipe d'accueil + 1.
+        // Évaluée uniquement si les deux divisions sont connues pour la saison.
+        $toStat = $teamStatRepository->findOneByTeamAndSeason($toTeam, $season);
+        $toLevel = $toStat?->getDivision()?->getLevel();
+
+        $playerLevel = null;
+        if ($fromTeam) {
+            $fromStat = $teamStatRepository->findOneByTeamAndSeason($fromTeam, $season);
+            $playerLevel = $fromStat?->getDivision()?->getLevel();
+        }
+
+        if ($toLevel !== null && $playerLevel !== null && $playerLevel > $toLevel + 1) {
+            throw ApiProblemException::badRequest(sprintf(
+                'Transfer not allowed: player division level (%d) must be at most destination team division level (%d) + 1',
+                $playerLevel,
+                $toLevel
+            ));
+        }
+
+        // Application du transfert.
+        $player->setTeam($toTeam);
+
+        $transfer = new Transfer();
+        $transfer->setPlayer($player);
+        $transfer->setFromTeam($fromTeam);
+        $transfer->setToTeam($toTeam);
+        $transfer->setSeason($season);
+
+        $this->entityManager->persist($transfer);
+        $this->entityManager->flush();
+
+        $this->logger->info('Player transferred', [
+            'player' => $player->getId(),
+            'from_team' => $fromTeam?->getId(),
+            'to_team' => $toTeam->getId(),
+            'season' => $season->getId(),
+        ]);
+
+        $response = $this->json($this->formatEntityData($transfer), 201);
+        $response->headers->set('Location', '/api/teams/' . $toTeam->getId() . '/transfers');
+        return $response;
+    }
+}

--- a/src/Entity/Transfer.php
+++ b/src/Entity/Transfer.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\TransferRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Transfert d'un joueur vers une équipe pour une saison donnée (issue app#28).
+ *
+ * Règles métier (appliquées par le contrôleur) :
+ * - au maximum 2 transferts entrants par équipe et par saison ;
+ * - autorisé si le niveau de division du joueur transféré (division de son
+ *   équipe d'origine) est <= niveau de division de l'équipe d'accueil + 1.
+ */
+#[ORM\Entity(repositoryClass: TransferRepository::class)]
+class Transfer
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Player $player = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?Team $fromTeam = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Team $toTeam = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Season $season = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getPlayer(): ?Player
+    {
+        return $this->player;
+    }
+
+    public function setPlayer(?Player $player): static
+    {
+        $this->player = $player;
+
+        return $this;
+    }
+
+    public function getFromTeam(): ?Team
+    {
+        return $this->fromTeam;
+    }
+
+    public function setFromTeam(?Team $fromTeam): static
+    {
+        $this->fromTeam = $fromTeam;
+
+        return $this;
+    }
+
+    public function getToTeam(): ?Team
+    {
+        return $this->toTeam;
+    }
+
+    public function setToTeam(?Team $toTeam): static
+    {
+        $this->toTeam = $toTeam;
+
+        return $this;
+    }
+
+    public function getSeason(): ?Season
+    {
+        return $this->season;
+    }
+
+    public function setSeason(?Season $season): static
+    {
+        $this->season = $season;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeImmutable $createdAt): static
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+}

--- a/src/EventListener/ApiSecurityListener.php
+++ b/src/EventListener/ApiSecurityListener.php
@@ -100,6 +100,11 @@ class ApiSecurityListener
             return true;
         }
 
+        // Match /api/teams/{id}/transfers (transfert par le capitaine d'accueil)
+        if (preg_match('#^/api/teams/\d+/transfers$#', $path)) {
+            return true;
+        }
+
         return false;
     }
 }

--- a/src/Repository/TeamStatRepository.php
+++ b/src/Repository/TeamStatRepository.php
@@ -34,6 +34,25 @@ class TeamStatRepository extends ServiceEntityRepository
         return $this->findBy(['division' => $division]);
     }
 
+    /**
+     * Retourne le TeamStat d'une équipe pour une saison donnée (via la division),
+     * ou null si l'équipe n'est rattachée à aucune division de cette saison.
+     */
+    public function findOneByTeamAndSeason(Team $team, \App\Entity\Season $season): ?TeamStat
+    {
+        $result = $this->createQueryBuilder('ts')
+            ->join('ts.division', 'd')
+            ->andWhere('ts.team = :team')
+            ->andWhere('d.season = :season')
+            ->setParameter('team', $team)
+            ->setParameter('season', $season)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $result instanceof TeamStat ? $result : null;
+    }
+
     //    /**
     //     * @return TeamStat[] Returns an array of TeamStat objects
     //     */

--- a/src/Repository/TransferRepository.php
+++ b/src/Repository/TransferRepository.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Season;
+use App\Entity\Team;
+use App\Entity\Transfer;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Transfer>
+ */
+class TransferRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Transfer::class);
+    }
+
+    /**
+     * Nombre de transferts entrants d'une équipe pour une saison.
+     */
+    public function countByToTeamAndSeason(Team $team, Season $season): int
+    {
+        return $this->count(['toTeam' => $team, 'season' => $season]);
+    }
+
+    /**
+     * @return Transfer[]
+     */
+    public function findByToTeamAndSeason(Team $team, Season $season): array
+    {
+        return $this->findBy(['toTeam' => $team, 'season' => $season], ['createdAt' => 'DESC']);
+    }
+}

--- a/tests/Functional/Controller/TransferControllerTest.php
+++ b/tests/Functional/Controller/TransferControllerTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use App\Tests\Functional\ApiTestCase;
+use App\Entity\Division;
+use App\Entity\Player;
+use App\Entity\Season;
+use App\Entity\Team;
+use App\Entity\TeamMember;
+use App\Entity\TeamStat;
+use App\Entity\Transfer;
+use App\Entity\User;
+
+/**
+ * Tests du flux de transfert de joueurs (issue app#28).
+ */
+class TransferControllerTest extends ApiTestCase
+{
+    private function makeSeason(): Season
+    {
+        $season = new Season();
+        $season->setName('Saison Transfert');
+        $this->entityManager->persist($season);
+        return $season;
+    }
+
+    private function makeTeam(string $name): Team
+    {
+        $team = new Team();
+        $team->setName($name);
+        $this->entityManager->persist($team);
+        return $team;
+    }
+
+    /**
+     * Crée un capitaine (ou membre) authentifié pour l'équipe donnée.
+     */
+    private function authenticateAs(Team $team, string $role = TeamMember::ROLE_CAPTAIN): User
+    {
+        $user = new User();
+        $user->setUsername('u_' . uniqid());
+        $user->setPassword('hashed');
+        $user->setRoles(['ROLE_USER']);
+        $user->setIsActive(true);
+        $user->setDiscordId('d_' . uniqid());
+        $this->entityManager->persist($user);
+
+        $member = new TeamMember();
+        $member->setUser($user);
+        $member->setRole($role);
+        $team->addMember($member);
+        $this->entityManager->persist($member);
+
+        $this->entityManager->flush();
+        $this->client->loginUser($user, 'api');
+
+        return $user;
+    }
+
+    private function putTeamInDivision(Team $team, Season $season, int $level): void
+    {
+        $division = new Division();
+        $division->setName('Division N' . $level);
+        $division->setSeason($season);
+        $division->setLevel($level);
+        $this->entityManager->persist($division);
+
+        $stat = new TeamStat();
+        $stat->setTeam($team);
+        $stat->setDivision($division);
+        $stat->setWins(0);
+        $stat->setLosses(0);
+        $stat->setTies(0);
+        $stat->setPoints(0);
+        $stat->setWinRounds(0);
+        $stat->setLooseRounds(0);
+        $this->entityManager->persist($stat);
+    }
+
+    private function makePlayer(string $name, ?Team $team): Player
+    {
+        $player = new Player();
+        $player->setName($name);
+        $player->setTeam($team);
+        $this->entityManager->persist($player);
+        return $player;
+    }
+
+    public function testCaptainCanTransferFreeAgent(): void
+    {
+        $season = $this->makeSeason();
+        $toTeam = $this->makeTeam('Accueil');
+        $player = $this->makePlayer('Agent Libre', null);
+        $this->entityManager->flush();
+
+        $this->authenticateAs($toTeam);
+
+        $response = $this->jsonRequest('POST', '/api/teams/' . $toTeam->getId() . '/transfers', [
+            'player_id' => $player->getId(),
+            'season_id' => $season->getId(),
+        ]);
+
+        $this->assertResponseStatusCode(201);
+        $this->assertEquals($player->getId(), $response['player_id']);
+        $this->assertEquals($toTeam->getId(), $response['to_team_id']);
+    }
+
+    public function testTransferRejectedByDivisionRule(): void
+    {
+        $season = $this->makeSeason();
+        $toTeam = $this->makeTeam('Elite');
+        $fromTeam = $this->makeTeam('Amateurs');
+        // Accueil en division 1 (haut), joueur en division 3 : 3 > 1 + 1 → refus.
+        $this->putTeamInDivision($toTeam, $season, 1);
+        $this->putTeamInDivision($fromTeam, $season, 3);
+        $player = $this->makePlayer('Joueur Bas', $fromTeam);
+        $this->entityManager->flush();
+
+        $this->authenticateAs($toTeam);
+
+        $this->jsonRequest('POST', '/api/teams/' . $toTeam->getId() . '/transfers', [
+            'player_id' => $player->getId(),
+            'season_id' => $season->getId(),
+        ]);
+
+        $this->assertResponseStatusCode(400);
+    }
+
+    public function testTransferAllowedWithinDivisionRule(): void
+    {
+        $season = $this->makeSeason();
+        $toTeam = $this->makeTeam('Elite');
+        $fromTeam = $this->makeTeam('Challengers');
+        // Accueil en division 1, joueur en division 2 : 2 <= 1 + 1 → autorisé.
+        $this->putTeamInDivision($toTeam, $season, 1);
+        $this->putTeamInDivision($fromTeam, $season, 2);
+        $player = $this->makePlayer('Joueur Proche', $fromTeam);
+        $this->entityManager->flush();
+
+        $this->authenticateAs($toTeam);
+
+        $response = $this->jsonRequest('POST', '/api/teams/' . $toTeam->getId() . '/transfers', [
+            'player_id' => $player->getId(),
+            'season_id' => $season->getId(),
+        ]);
+
+        $this->assertResponseStatusCode(201);
+        $this->assertEquals($fromTeam->getId(), $response['from_team_id']);
+    }
+
+    public function testMaxTransfersPerSeason(): void
+    {
+        $season = $this->makeSeason();
+        $toTeam = $this->makeTeam('Recruteur');
+
+        // 2 transferts déjà enregistrés cette saison.
+        for ($i = 0; $i < 2; $i++) {
+            $p = $this->makePlayer('Déjà ' . $i, null);
+            $t = new Transfer();
+            $t->setPlayer($p);
+            $t->setToTeam($toTeam);
+            $t->setSeason($season);
+            $this->entityManager->persist($t);
+        }
+
+        $player = $this->makePlayer('Troisième', null);
+        $this->entityManager->flush();
+
+        $this->authenticateAs($toTeam);
+
+        $this->jsonRequest('POST', '/api/teams/' . $toTeam->getId() . '/transfers', [
+            'player_id' => $player->getId(),
+            'season_id' => $season->getId(),
+        ]);
+
+        $this->assertResponseStatusCode(400);
+    }
+
+    public function testNonCaptainCannotTransfer(): void
+    {
+        $season = $this->makeSeason();
+        $toTeam = $this->makeTeam('Accueil');
+        $player = $this->makePlayer('Agent Libre', null);
+        $this->entityManager->flush();
+
+        $this->authenticateAs($toTeam, TeamMember::ROLE_MEMBER);
+
+        $this->jsonRequest('POST', '/api/teams/' . $toTeam->getId() . '/transfers', [
+            'player_id' => $player->getId(),
+            'season_id' => $season->getId(),
+        ]);
+
+        $this->assertResponseStatusCode(403);
+    }
+
+    public function testPlayerIdRequired(): void
+    {
+        $season = $this->makeSeason();
+        $toTeam = $this->makeTeam('Accueil');
+        $this->entityManager->flush();
+
+        $this->authenticateAs($toTeam);
+
+        $this->jsonRequest('POST', '/api/teams/' . $toTeam->getId() . '/transfers', [
+            'season_id' => $season->getId(),
+        ]);
+
+        $this->assertResponseStatusCode(400);
+    }
+
+    public function testListTransfersBySeason(): void
+    {
+        $season = $this->makeSeason();
+        $toTeam = $this->makeTeam('Accueil');
+        $player = $this->makePlayer('Transféré', null);
+        $transfer = new Transfer();
+        $transfer->setPlayer($player);
+        $transfer->setToTeam($toTeam);
+        $transfer->setSeason($season);
+        $this->entityManager->persist($transfer);
+        $this->entityManager->flush();
+
+        $response = $this->jsonRequest('GET', '/api/teams/' . $toTeam->getId() . '/transfers?season_id=' . $season->getId());
+
+        $this->assertResponseStatusCode(200);
+        $this->assertCount(1, $response);
+        $this->assertEquals($player->getId(), $response[0]['player_id']);
+    }
+}


### PR DESCRIPTION
Débloque **SBL-app#28** (transferts) côté API.

## Règles métier (issue)
- [x] **2 par équipe et par saison** — max 2 transferts entrants par équipe/saison
- [x] **ok si `div.nouveau_joueur <= div.équipe + 1`** — le niveau de division du joueur transféré doit être au plus le niveau de l'équipe d'accueil + 1 (rappel : `level 1` = division la plus haute, via l'entité `Division.level` de #36)

## Endpoints
- `POST /api/teams/{teamId}/transfers` — le **capitaine de l'équipe d'accueil** (ou un **admin**) transfère un joueur dans son équipe. Corps : `{player_id, season_id?}` (saison courante par défaut).
- `GET /api/teams/{teamId}/transfers[?season_id=]` — liste des transferts entrants (lecture publique).

## Détails
- Entité `Transfer` (player, fromTeam, toTeam, season, createdAt) + `TransferRepository` (`countByToTeamAndSeason`)
- `TeamStatRepository::findOneByTeamAndSeason` pour résoudre la division d'une équipe dans une saison
- La règle de division n'est appliquée que si les deux divisions sont connues pour la saison (un agent libre sans division est transférable)
- Accès `ROLE_USER` : règle `security.yaml` + whitelist `ApiSecurityListener`
- Migration `Version20260723140000` (PostgreSQL)

## Tests
Transfert d'un agent libre (201), règle de division respectée/refusée (201/400), quota de 2/saison (400), non-capitaine (403), `player_id` requis (400), listing par saison.

## Suite (front)
Reste à ajouter l'UI côté SBL-app (bouton « recruter/transférer » sur la fiche équipe appelant ce endpoint) — je peux l'enchaîner si tu veux.

> Base = `feat/backend-v2-integrated`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)