### PR TITLE
chore(bloc4): journal de versions, fiche de consignation et Dependabot

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,183 @@
+name: "Fiche de consignation d'anomalie"
+description: "Consigner une anomalie détectée en production ou en recette"
+title: "[BUG] "
+labels: ["type:bug", "statut:a-trier"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Consignation d'une anomalie
+
+        Cette fiche structure la collecte des informations nécessaires à la
+        **reproduction** puis à la **correction** de l'anomalie. Les champs
+        marqués d'un astérisque sont obligatoires : sans eux, l'anomalie ne
+        peut pas être reproduite de façon fiable et le correctif risque de
+        traiter un symptôme plutôt que la cause.
+
+  - type: dropdown
+    id: source
+    attributes:
+      label: Source de la détection
+      description: Par quel canal l'anomalie est-elle remontée ?
+      options:
+        - Sentry (détection automatique)
+        - Uptime Kuma (alerte de supervision)
+        - Retour du staff SBL (client)
+        - Retour d'un joueur (utilisateur final)
+        - Tests automatisés (CI)
+        - Constatée en développement
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severite
+    attributes:
+      label: Sévérité
+      description: |
+        S1 — Service indisponible ou perte de données, aucun contournement possible
+        S2 — Fonctionnalité majeure inutilisable, contournement complexe
+        S3 — Fonctionnalité secondaire dégradée, contournement simple
+        S4 — Défaut cosmétique ou confort
+      options:
+        - "S1 — Critique"
+        - "S2 — Majeure"
+        - "S3 — Mineure"
+        - "S4 — Cosmétique"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: composant
+    attributes:
+      label: Composant concerné
+      options:
+        - API (Symfony)
+        - Frontend (Vue 3)
+        - Bot Discord
+        - Scheduler
+        - Base de données
+        - Infrastructure / déploiement
+        - Indéterminé
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version applicative
+      description: >
+        Valeur du champ `version` retourné par `/api/health`, ou tag de la
+        release concernée. Permet de relier l'anomalie à une entrée précise
+        du journal de versions.
+      placeholder: "v1.4.2 (commit a3f9c1d2)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environnement
+    attributes:
+      label: Environnement
+      options:
+        - Production
+        - Développement local
+        - Environnement de test (CI)
+    validations:
+      required: true
+
+  - type: textarea
+    id: contexte
+    attributes:
+      label: Contexte d'apparition
+      description: >
+        Qui a rencontré le problème, dans quelles circonstances, et depuis
+        quand. Préciser si l'anomalie est apparue après un déploiement.
+      placeholder: |
+        Signalé par le staff SBL le 12/08 sur Discord.
+        Concerne les capitaines d'équipe uniquement.
+        Apparu après le déploiement de la v1.4.2.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Étapes de reproduction
+      description: >
+        Séquence numérotée et minimale permettant de reproduire l'anomalie.
+        C'est le champ le plus important de la fiche : une anomalie non
+        reproductible ne peut pas être corrigée de manière fiable.
+      placeholder: |
+        1. Se connecter avec un compte capitaine d'équipe
+        2. Ouvrir la page « Mes matchs »
+        3. Cliquer sur « Proposer une date » pour un match déjà joué
+        4. Observer l'erreur
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: attendu
+    attributes:
+      label: Comportement attendu
+      placeholder: "Le bouton ne devrait pas être proposé sur un match déjà joué."
+    validations:
+      required: true
+
+  - type: textarea
+    id: constate
+    attributes:
+      label: Comportement constaté
+      placeholder: "Une erreur 500 est renvoyée et la page reste bloquée sur le chargement."
+    validations:
+      required: true
+
+  - type: input
+    id: sentry
+    attributes:
+      label: Lien Sentry
+      description: >
+        URL de l'événement Sentry associé, s'il existe. Il contient la stack
+        trace complète, le contexte de la requête et la release concernée.
+      placeholder: "https://sentry.io/organizations/.../issues/..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Journaux et messages d'erreur
+      description: >
+        Extrait de `docker compose logs api`, réponse HTTP brute, ou console
+        du navigateur. Le formatage en bloc de code est automatique.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact utilisateurs
+      description: >
+        Nombre d'utilisateurs affectés, contournement disponible, urgence
+        réelle. Cet élément conditionne l'arbitrage de priorisation.
+      placeholder: |
+        8 capitaines sur 24 concernés.
+        Contournement : passer par la page du match plutôt que par « Mes matchs ».
+    validations:
+      required: true
+
+  - type: textarea
+    id: analyse
+    attributes:
+      label: Analyse préliminaire et piste de correction
+      description: >
+        À compléter lors du triage. Cause suspectée et correctif envisagé.
+      placeholder: |
+        Cause suspectée : le contrôle du statut du match est absent côté front.
+        Piste : filtrer sur gameStatus dans le composant, et durcir la
+        validation côté API pour empêcher toute proposition sur un match clos.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Incident de production en cours
+    url: https://discord.com/channels/
+    about: >
+      Pour une indisponibilité constatée en production (sévérité S1), signaler
+      d'abord sur le canal #alertes-technique afin d'accélérer la prise en
+      charge, puis créer la fiche de consignation.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: "Demande d'évolution"
+description: "Proposer une nouvelle fonctionnalité ou une amélioration"
+title: "[FEAT] "
+labels: ["type:feature", "statut:a-trier"]
+body:
+  - type: dropdown
+    id: demandeur
+    attributes:
+      label: Origine de la demande
+      options:
+        - Staff SBL (client)
+        - Joueur (utilisateur final)
+        - Initiative technique (dette, performance, sécurité)
+    validations:
+      required: true
+
+  - type: textarea
+    id: besoin
+    attributes:
+      label: Besoin exprimé
+      description: Décrire le besoin métier, sans présumer de la solution technique.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solution envisagée
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priorite
+    attributes:
+      label: Priorité proposée
+      options:
+        - Haute — bloquant pour la saison en cours
+        - Moyenne — à planifier sur le trimestre
+        - Basse — backlog
+    validations:
+      required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,91 @@
+version: 2
+
+# Processus de mise à jour des dépendances — API Symfony (C4.1.1)
+#
+# Périmètre  : dépendances PHP (Composer), image de base Docker, actions CI.
+# Fréquence  : hebdomadaire le lundi — les correctifs de sécurité restent
+#              proposés immédiatement par GitHub, indépendamment de ce rythme.
+# Mode       : automatique pour la détection et l'ouverture des pull requests,
+#              manuel pour la validation. Aucune fusion automatique : sur un
+#              projet servant une ligue en activité, une régression introduite
+#              sans relecture coûte plus cher que le délai de revue.
+
+updates:
+  # ---------------------------------------------------------------
+  # Dépendances PHP
+  # ---------------------------------------------------------------
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: Europe/Paris
+    open-pull-requests-limit: 5
+    target-branch: dev
+    labels:
+      - "type:deps"
+      - "composant:api"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "chore"
+      include: scope
+    groups:
+      # Les composants Symfony sont interdépendants : les mettre à jour
+      # séparément produit des pull requests en échec de CI, chacune attendant
+      # les autres. Le regroupement rend l'ensemble testable en une fois.
+      symfony:
+        patterns:
+          - "symfony/*"
+        update-types:
+          - minor
+          - patch
+      doctrine:
+        patterns:
+          - "doctrine/*"
+        update-types:
+          - minor
+          - patch
+      # Les montées de version des outils de développement ne présentent aucun
+      # risque en production : elles sont regroupées pour limiter le bruit.
+      dev-tools:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # Les versions majeures sont exclues du flux automatique : elles
+      # impliquent des ruptures de compatibilité qui relèvent d'une décision
+      # de planification, pas d'une revue de pull request hebdomadaire.
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+
+  # ---------------------------------------------------------------
+  # Image de base Docker
+  # ---------------------------------------------------------------
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: Europe/Paris
+    labels:
+      - "type:deps"
+      - "composant:infra"
+    commit-message:
+      prefix: "deps"
+
+  # ---------------------------------------------------------------
+  # Actions GitHub utilisées par la CI
+  # ---------------------------------------------------------------
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    labels:
+      - "type:deps"
+      - "composant:infra"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,106 @@
+name: Release
+
+# Génération du journal des versions et publication d'une release GitHub.
+#
+# Déclenchement manuel plutôt qu'automatique sur chaque merge : sur ce projet,
+# plusieurs correctifs sont souvent fusionnés dans la même journée. Publier une
+# release par merge produirait un journal illisible pour le staff SBL. Le
+# déclenchement manuel permet de regrouper un ensemble cohérent d'évolutions,
+# tout en conservant une génération entièrement automatique du contenu.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Type d'incrément sémantique"
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Publier une nouvelle version
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Récupérer le dépôt
+        uses: actions/checkout@v4
+        with:
+          # L'historique complet et les tags sont nécessaires : git-cliff
+          # calcule la version suivante à partir du dernier tag existant.
+          fetch-depth: 0
+
+      - name: Calculer la version suivante
+        id: version
+        run: |
+          set -euo pipefail
+          dernier_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          version=${dernier_tag#v}
+
+          IFS='.' read -r majeure mineure correctif <<< "$version"
+
+          case "${{ inputs.bump }}" in
+            major) majeure=$((majeure + 1)); mineure=0; correctif=0 ;;
+            minor) mineure=$((mineure + 1)); correctif=0 ;;
+            patch) correctif=$((correctif + 1)) ;;
+          esac
+
+          nouvelle="v${majeure}.${mineure}.${correctif}"
+          echo "precedente=${dernier_tag}" >> "$GITHUB_OUTPUT"
+          echo "nouvelle=${nouvelle}" >> "$GITHUB_OUTPUT"
+          echo "Version : ${dernier_tag} -> ${nouvelle}"
+
+      - name: Générer le journal des versions
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --tag ${{ steps.version.outputs.nouvelle }}
+        env:
+          OUTPUT: CHANGELOG.md
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extraire les notes de la version
+        id: notes
+        run: |
+          set -euo pipefail
+          # Les notes de release reprennent la seule section de la nouvelle
+          # version, et non l'intégralité du journal.
+          awk '/^## \[/{n++} n==1' CHANGELOG.md > NOTES.md
+          {
+            echo 'contenu<<DELIMITEUR'
+            cat NOTES.md
+            echo 'DELIMITEUR'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Committer le journal mis à jour
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet CHANGELOG.md; then
+            echo "Aucune évolution à consigner depuis ${{ steps.version.outputs.precedente }}."
+            exit 1
+          fi
+
+          git add CHANGELOG.md
+          git commit -m "chore(release): ${{ steps.version.outputs.nouvelle }}"
+          git tag -a "${{ steps.version.outputs.nouvelle }}" \
+            -m "Release ${{ steps.version.outputs.nouvelle }}"
+          git push origin HEAD --follow-tags
+
+      - name: Publier la release GitHub
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.nouvelle }}
+          name: ${{ steps.version.outputs.nouvelle }}
+          body: ${{ steps.notes.outputs.contenu }}
+          draft: false
+          prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,216 @@
+# Journal des versions — API SBL
+
+Toutes les évolutions notables de l'API Symfony sont consignées dans ce fichier.
+
+Le format suit [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/) et le
+versionnage respecte le [Semantic Versioning](https://semver.org/lang/fr/).
+
+> **Note sur la reconstitution.** Le projet a démarré sans convention de commit
+> ni tags SemVer. Les versions `0.1.0` à `0.5.0` ont donc été reconstituées a
+> posteriori à partir de l'historique Git (plus de 180 commits depuis le
+> 03/05/2024), en retenant comme jalons les incréments effectivement livrés et
+> validés avec le staff SBL lors des points mensuels. Les versions `1.0.0` et
+> suivantes correspondent à des **tags Git réels** posés sur la branche `main`.
+> À partir de la version `2.0.0`, ce fichier est généré automatiquement par
+> `git-cliff` à chaque release (voir `.github/workflows/release.yml`).
+
+---
+
+## [Non publié]
+
+Développé sur la branche `dev`, en attente de fusion vers `main`.
+
+### Ajouté
+
+- **Playoffs** : entités `Bracket` et `BracketEntry`, génération de brackets à
+  élimination simple avec gestion des byes et de la petite finale
+  (`BracketGeneratorService`)
+- **Têtes de série** : `BracketSeedingService` détermine les seeds depuis le
+  classement de division
+- **Progression automatique** : `BracketProgressionService` fait avancer les
+  vainqueurs, déclenché depuis le flux de résultat et depuis le forfait
+- `BracketController` — CRUD, seeding et génération
+- Clôture automatique des saisons et divisions lorsque tous les matchs sont
+  joués (#32)
+- Import des résultats de la saison 3
+
+### Corrigé
+
+- Contrôle administrateur manquant sur `createBracket`
+- Garde contre la re-résolution d'un match aval déjà joué
+- Nettoyage du schéma de test via `dropDatabase()`, plus robuste que
+  `dropSchema()` face aux clés étrangères auto-référentes de `Game`
+
+---
+
+## [2.0.0] — 2026-07-23
+
+**Version majeure.** Refonte du backend introduisant l'authentification sur
+l'ensemble des endpoints d'écriture. Le contrat de l'API change pour ses deux
+clients — frontend Vue et bot Discord — qui doivent être déployés de façon
+coordonnée. C'est précisément ce qu'un incrément majeur signale dans ce projet.
+
+Périmètre : 261 fichiers modifiés, environ 30 000 lignes ajoutées.
+
+### Ajouté
+
+- **Authentification** : JWT (LexikJWTAuthenticationBundle), OAuth Discord,
+  clés d'API à expiration pour les accès de service (#23)
+- **Gestion des résultats de match** : soumission par une équipe, confirmation
+  par l'équipe adverse, passage automatique en litige après délai (#33, #2)
+- **Notifications** : notifications push Web (VAPID), rappels et échéances
+  automatiques pilotés par le scheduler Symfony (#24)
+- **Comptes rendus de match** et statut de jeu `reported`
+- **Membres d'équipe** : entité `TeamMember` et endpoints associés
+- Calcul automatique des `TeamStat` après validation d'un résultat
+- Propositions de match (`MatchProposal`) et génération du calendrier de
+  division
+- `GET /games/unscheduled` — matchs non planifiés
+- `GET /season/current/week` et `PATCH /games/{id}/schedule`
+- Journalisation applicative structurée (Monolog, canal `app`) et alertes
+  e-mail sur erreur en production
+
+### Modifié
+
+- **Migration du SGBD de MySQL vers PostgreSQL** — décision prise pour
+  s'affranchir de la licence propriétaire Oracle et préparer la montée en
+  charge
+- Conteneurisation complète de la production (Docker, Traefik, PHP 8.3)
+
+### Sécurité
+
+- Endpoints `POST`, `PUT`, `PATCH` et `DELETE` désormais soumis à
+  authentification
+- Suppression d'un fichier d'identifiants du dépôt et remplacement des clés
+  push d'exemple
+
+---
+
+## [1.1.0] — 2026-07-19
+
+Version consacrée à la qualité et à l'outillage, sans évolution fonctionnelle
+visible par les utilisateurs.
+
+### Ajouté
+
+- **Chaîne d'intégration continue** : exécution de PHPUnit, analyse statique
+  PHPStan et vérification de style PHP CS-Fixer sur chaque pull request
+- Durcissement de la configuration selon les recommandations OWASP
+- Couverture de test des endpoints d'équipes de saison et du pourcentage de
+  matchs joués
+
+### Sécurité
+
+- `symfony/process` 7.3.0 → 7.4.5 (Dependabot)
+- `symfony/http-foundation` 7.3.0 → 7.4.1 (Dependabot)
+
+---
+
+## [1.0.0] — 2025-06-26
+
+**Première mise en production.** L'API quitte l'environnement de développement
+et sert le site public de la ligue.
+
+### Ajouté
+
+- Fichiers de configuration nécessaires au déploiement
+
+### Corrigé
+
+- Configuration CORS et route racine par défaut
+- Corrections diverses bloquant le déploiement
+
+### Sécurité
+
+- Désactivation des routes `POST`, `PUT`, `PATCH` et `DELETE` en attendant la
+  mise en place de l'authentification, livrée en `2.0.0`
+
+---
+
+## [0.5.0] — 2025-04-12
+
+### Ajouté
+
+- Champs complémentaires sur `TeamStat`
+- Configuration Apache / cPanel pour le premier hébergement
+
+### Modifié
+
+- Présentation des informations d'équipe
+
+### Corrigé
+
+- Calcul et filtrage du pourcentage de matchs joués
+
+---
+
+## [0.4.0] — 2024-12-21
+
+### Ajouté
+
+- **Inscriptions** : entité `Registration` et contrôleur associé
+
+### Modifié
+
+- `getSeasonTeams` s'appuie désormais sur le dépôt `Registration`
+
+### Corrigé
+
+- Autorisation des champs nuls à la création d'un match
+
+---
+
+## [0.3.0] — 2024-11-10
+
+### Ajouté
+
+- `getSeasonGames`, `getSeasonTeams`, `getSeasonGamesByStatus`
+- `getFinishedMatchPourcent` — taux d'avancement d'une saison
+- Récupération des matchs par division
+
+### Modifié
+
+- Structure des réponses uniformisée
+
+### Corrigé
+
+- Erreur de calcul sur `totalGames` dans le pourcentage d'avancement
+
+---
+
+## [0.2.0] — 2024-07-15
+
+### Ajouté
+
+- `getTeamStatByDivision`, `getPlayerByTeam`, `getGamesByTeam`
+- `getDivisionBySeason` enrichi des informations d'équipe
+
+### Modifié
+
+- Revue complète du nommage des routes et de leurs arguments (#2)
+- Passage à `EntityManagerInterface` dans les contrôleurs
+
+### Corrigé
+
+- Erreurs CORS bloquant les appels depuis le frontend
+
+---
+
+## [0.1.0] — 2024-05-16
+
+Première version fonctionnelle de l'API.
+
+### Ajouté
+
+- Entités `Team`, `TeamStat`, `Division`, `Season`, `Player`, `Game`,
+  `GameStatus` et leurs contrôleurs CRUD
+- Relation entre `Game` et `Division`
+- Jeux de données de développement (Faker)
+- Documentation initiale
+
+---
+
+[Non publié]: https://github.com/SBL-app/api/compare/v2.0.0...dev
+[2.0.0]: https://github.com/SBL-app/api/releases/tag/v2.0.0
+[1.1.0]: https://github.com/SBL-app/api/releases/tag/v1.1.0
+[1.0.0]: https://github.com/SBL-app/api/releases/tag/v1.0.0

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,83 @@
+# Configuration git-cliff — génération automatique du journal de versions.
+#
+# Le journal de versions ne doit pas dépendre de la discipline de rédaction
+# manuelle : sur un projet mené en solo sur deux ans, un CHANGELOG tenu à la
+# main finit systématiquement par diverger du code réellement déployé.
+# La génération depuis les messages de commit garantit qu'aucune modification
+# fusionnée sur main ne peut échapper au journal.
+
+[changelog]
+header = """
+# Journal des versions — API SBL
+
+Toutes les évolutions notables de l'API Symfony sont consignées dans ce fichier.
+
+Le format suit [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/) et le
+versionnage respecte le [Semantic Versioning](https://semver.org/lang/fr/).\n
+"""
+
+body = """
+{% if version %}
+## [{{ version | trim_start_matches(pat="v") }}] — {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}
+## [Non publié]
+{% endif %}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | upper_first }}\
+{% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }})){% endif %}\
+ ([{{ commit.id | truncate(length=7, end="") }}]({{ self::remote_url() }}/commit/{{ commit.id }}))\
+{% endfor %}
+{% endfor %}\n
+"""
+
+trim = true
+
+footer = """
+<!-- Généré par git-cliff -->
+"""
+
+[changelog.remote.github]
+owner = "SBL-app"
+repo = "api"
+
+[git]
+# Le versionnage sémantique est déduit des préfixes de commit :
+# feat! ou BREAKING CHANGE -> majeure, feat -> mineure, fix -> patch.
+conventional_commits = true
+
+# Les commits hors convention sont volontairement écartés plutôt que classés
+# dans un fourre-tout : un journal de versions doit rester lisible par le
+# client, pas exhaustif au sens technique.
+filter_unconventional = true
+
+split_commits = false
+protect_breaking_commits = true
+filter_commits = false
+topo_order = false
+sort_commits = "newest"
+
+commit_parsers = [
+  { message = "^feat", group = "Ajouté" },
+  { message = "^fix", group = "Corrigé" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Modifié" },
+  { message = "^security", group = "Sécurité" },
+  { message = "^deps", group = "Sécurité" },
+  { message = "^revert", group = "Annulé" },
+  { message = "^docs", skip = true },
+  { message = "^test", skip = true },
+  { message = "^chore", skip = true },
+  { message = "^ci", skip = true },
+  { message = "^style", skip = true },
+  { message = "^Merge", skip = true },
+]
+
+commit_preprocessors = [
+  # Retire le préfixe conventionnel du texte affiché : il est déjà porté par
+  # le titre de section.
+  { pattern = '^(feat|fix|perf|refactor|security|deps|revert)(\\([^)]*\\))?!?: *', replace = "" },
+]
+
+tag_pattern = "v[0-9]*"


### PR DESCRIPTION
Active les mécanismes GitHub qui n'ont d'effet que depuis la branche par défaut :

- **Dependabot** — surveillance hebdomadaire des dépendances
- **Formulaire de consignation d'anomalie** — champs de reproduction bloquants
- **Workflow de release** — tag SemVer, CHANGELOG et release GitHub

Aucun code applicatif n'est modifié : cette branche ne contient que des fichiers
de configuration et de documentation. Le code de supervision (`HealthController`,
handler Monolog, heartbeat du bot) reste sur `dev` et sera fusionné par le
circuit habituel.

Référence : Bloc 4 — maintien en condition opérationnelle.