### PR TITLE
ci(cd): rendre l'échec du déploiement diagnosticable

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,8 +8,9 @@ name: CD
 # healthcheck : quand il plante au démarrage, il redémarre en boucle et
 # `docker compose exec` échoue sur un message opaque (`exit code 137`, ou
 # `Container ... is restarting` selon la version du démon). Le déploiement
-# attend donc que le conteneur soit stable avant de lancer les migrations, et
-# publie les logs du conteneur quand quelque chose échoue.
+# attend donc que le conteneur soit stable avant de lancer les migrations. En
+# cas d'échec sur un déclenchement manuel, les logs du conteneur sont publiés
+# (voir la note sur cette étape).
 #
 # Secrets requis :
 #   SSH_HOST, SSH_USER, SSH_KEY, SSH_PORT (optionnel, défaut 22), DEPLOY_PATH
@@ -126,11 +127,17 @@ jobs:
             "cd '$DEPLOY_PATH' && docker image prune -f"
 
       # Sans ça, un plantage du conteneur n'est lisible qu'en se connectant au
-      # serveur. Les identifiants présents dans les URI (DATABASE_URL et
-      # consorts) sont masqués avant affichage — voir la note de la PR sur la
-      # limite de ce filtrage.
+      # serveur.
+      #
+      # Volontairement limité à `workflow_dispatch` : le dépôt est public, et
+      # les logs d'un Symfony en `APP_ENV: prod` peuvent contenir des
+      # identifiants. Le filtrage ci-dessous masque les formes connues
+      # (identifiants d'URI, variables sensibles) mais ne peut pas tout couvrir.
+      # Ces valeurs venant du `.env` du serveur et non des secrets GitHub, le
+      # masquage automatique d'Actions ne s'y applique pas. On ne publie donc
+      # ces logs que sur un déclenchement manuel, quand quelqu'un les regarde.
       - name: Collect container diagnostics
-        if: failure()
+        if: failure() && github.event_name == 'workflow_dispatch'
         run: |
           set -uo pipefail
           ssh -i ~/.ssh/deploy_key -p "$SSH_PORT" "$SSH_TARGET" \

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,13 @@ name: CD
 # le sous-dossier `api/` de la stack sur le serveur, rebuild du service `api`
 # (PHP-FPM) via docker compose, puis exécution des migrations Doctrine.
 #
+# Le service `api` tourne en `restart: unless-stopped` et n'a pas de
+# healthcheck : quand il plante au démarrage, il redémarre en boucle et
+# `docker compose exec` échoue sur un message opaque (`exit code 137`, ou
+# `Container ... is restarting` selon la version du démon). Le déploiement
+# attend donc que le conteneur soit stable avant de lancer les migrations, et
+# publie les logs du conteneur quand quelque chose échoue.
+#
 # Secrets requis :
 #   SSH_HOST, SSH_USER, SSH_KEY, SSH_PORT (optionnel, défaut 22), DEPLOY_PATH
 
@@ -20,6 +27,10 @@ jobs:
   deploy:
     name: Deploy API over SSH
     runs-on: ubuntu-latest
+    env:
+      SSH_PORT: ${{ secrets.SSH_PORT || '22' }}
+      SSH_TARGET: ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}
+      DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
     steps:
       - uses: actions/checkout@v4
 
@@ -29,7 +40,7 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -p "${{ secrets.SSH_PORT || '22' }}" -H "${{ secrets.SSH_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
+          ssh-keyscan -p "$SSH_PORT" -H "${{ secrets.SSH_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
 
       - name: Sync API source
         run: |
@@ -40,18 +51,98 @@ jobs:
             --exclude 'vendor' \
             --exclude 'var' \
             --exclude '.env.local' \
-            -e "ssh -i ~/.ssh/deploy_key -p ${{ secrets.SSH_PORT || '22' }}" \
-            ./ "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${{ secrets.DEPLOY_PATH }}/api/"
+            -e "ssh -i ~/.ssh/deploy_key -p $SSH_PORT" \
+            ./ "$SSH_TARGET:$DEPLOY_PATH/api/"
 
-      - name: Rebuild service & run migrations
+      - name: Rebuild service
         run: |
           set -euo pipefail
-          ssh -i ~/.ssh/deploy_key -p "${{ secrets.SSH_PORT || '22' }}" \
-            "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
-            "cd '${{ secrets.DEPLOY_PATH }}' \
-              && docker compose up -d --build api api-nginx \
-              && docker compose exec -T api php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration \
-              && docker image prune -f"
+          ssh -i ~/.ssh/deploy_key -p "$SSH_PORT" "$SSH_TARGET" \
+            "cd '$DEPLOY_PATH' && docker compose up -d --build api api-nginx"
+
+      # `docker compose up -d` rend la main dès que le conteneur est lancé, pas
+      # quand il est viable. On vérifie qu'il tient debout avant d'aller plus
+      # loin : `up --build` venant de recréer le conteneur, tout redémarrage
+      # compté ici est forcément postérieur au déploiement, donc un crash.
+      - name: Wait for the api container to stabilise
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/deploy_key -p "$SSH_PORT" "$SSH_TARGET" \
+            "cd '$DEPLOY_PATH' && bash -s" <<'REMOTE'
+          set -uo pipefail
+
+          cid=$(docker compose ps -q api || true)
+          if [ -z "$cid" ]; then
+            echo "::error::conteneur api introuvable après 'docker compose up'"
+            exit 1
+          fi
+
+          stable=0
+          for attempt in $(seq 1 30); do
+            status=$(docker inspect -f '{{.State.Status}}' "$cid")
+            restarts=$(docker inspect -f '{{.RestartCount}}' "$cid")
+
+            if [ "$restarts" -gt 0 ]; then
+              echo "::error::le conteneur api a redémarré $restarts fois depuis sa recréation : il plante au démarrage"
+              exit 1
+            fi
+
+            case "$status" in
+              running)
+                stable=$((stable + 1))
+                # Trois relevés consécutifs : un conteneur qui plante après une
+                # seconde ne doit pas être déclaré sain.
+                if [ "$stable" -ge 3 ]; then
+                  echo "conteneur api stable (running, 0 redémarrage)"
+                  exit 0
+                fi
+                ;;
+              restarting|created)
+                stable=0
+                echo "api est '$status' (tentative $attempt/30)…"
+                ;;
+              exited|dead)
+                echo "::error::le conteneur api est '$status'"
+                exit 1
+                ;;
+            esac
+            sleep 2
+          done
+
+          echo "::error::le conteneur api n'est pas devenu stable en 60 s"
+          exit 1
+          REMOTE
+
+      - name: Run Doctrine migrations
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/deploy_key -p "$SSH_PORT" "$SSH_TARGET" \
+            "cd '$DEPLOY_PATH' && docker compose exec -T api php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration"
+
+      - name: Prune dangling images
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/deploy_key -p "$SSH_PORT" "$SSH_TARGET" \
+            "cd '$DEPLOY_PATH' && docker image prune -f"
+
+      # Sans ça, un plantage du conteneur n'est lisible qu'en se connectant au
+      # serveur. Les identifiants présents dans les URI (DATABASE_URL et
+      # consorts) sont masqués avant affichage — voir la note de la PR sur la
+      # limite de ce filtrage.
+      - name: Collect container diagnostics
+        if: failure()
+        run: |
+          set -uo pipefail
+          ssh -i ~/.ssh/deploy_key -p "$SSH_PORT" "$SSH_TARGET" \
+            "cd '$DEPLOY_PATH' \
+              && echo '--- docker compose ps ---' \
+              && docker compose ps \
+              && echo '--- docker compose logs api (100 dernières lignes) ---' \
+              && docker compose logs --tail=100 --no-color api" 2>&1 \
+            | sed -E \
+                -e 's#(://[^:/@[:space:]]*):[^@[:space:]]+@#\1:***@#g' \
+                -e 's#((APP_SECRET|APP_PASSWORD|JWT_PASSPHRASE|POSTGRES_PASSWORD|DISCORD_CLIENT_SECRET|DISCORD_BOT_SECRET|MAILER_DSN)[[:space:]]*[=:][[:space:]]*)[^[:space:]]+#\1***#gi' \
+            || true
 
       - name: Clean up SSH key
         if: always()


### PR DESCRIPTION
## Constat

**Le workflow CD n'a jamais abouti. 7 exécutions depuis le 19/07, 7 échecs.**

| Exécutions | Étape en échec |
|---|---|
| 4 runs (19/07) | `Configure SSH` |
| 3 runs (23/07 → 19/08) | `Rebuild service & run migrations` |

Les trois dernières échouent sur `exit code 137`, sans **aucune** sortie de la commande de migration. Relancé seul, sans déploiement concurrent, le résultat est identique — [run 32294080216](https://github.com/SBL-app/api/actions/runs/32294080216).

## Cause

Visible dans le [run du 23/07](https://github.com/SBL-app/api/actions/runs/30002330709), où le démon Docker était encore explicite :

```
Error response from daemon: Container 6b00f86f... is restarting,
wait until the container is running
```

Le conteneur `sbl-api` **plante au démarrage et redémarre en boucle** — `restart: unless-stopped`, aucun healthcheck sur le service. `docker compose exec` tombe sur un conteneur en redémarrage et se fait tuer. En juillet Docker renvoyait ce message et `exit 1` ; les versions récentes renvoient `137`. Même panne, message dégradé.

**Les migrations Doctrine n'ont donc jamais tourné via ce pipeline.**

## Ce que fait cette PR

Elle **ne corrige pas** le plantage du conteneur — la cause est dans les logs du conteneur, inaccessibles depuis le workflow aujourd'hui. Elle rend cette panne, et les suivantes, lisibles sans SSH.

- **Découpage de l'étape monolithique** en `Rebuild service` / `Run Doctrine migrations` / `Prune dangling images`. Le nom de l'étape en échec désigne enfin l'opération qui a échoué.
- **Étape d'attente** avant les migrations : le conteneur doit être `running` sur trois relevés consécutifs et afficher zéro redémarrage. `up --build` venant de le recréer, tout redémarrage compté est postérieur au déploiement — donc un crash. La boucle est signalée telle quelle :
  ```
  ::error::le conteneur api a redémarré 3 fois depuis sa recréation : il plante au démarrage
  ```
  Cas couverts : conteneur absent, `restarting`, `exited`/`dead`, jamais stable en 60 s. Active sur **tous** les déploiements, et ne publie rien.
- **Étape de diagnostic**, limitée aux déclenchements manuels (`if: failure() && github.event_name == 'workflow_dispatch'`) : publication de `docker compose ps` et des 100 dernières lignes de `docker compose logs api`.

## Pourquoi le diagnostic est limité au déclenchement manuel

Le dépôt est **public**, et les logs d'un Symfony en `APP_ENV: prod` qui n'arrive pas à joindre sa base recrachent volontiers `DATABASE_URL`, mot de passe compris. Les identifiants d'URI et les variables sensibles (`APP_SECRET`, `JWT_PASSPHRASE`, `POSTGRES_PASSWORD`, `DISCORD_*_SECRET`, `MAILER_DSN`) sont masqués avant affichage :

```
DATABASE_URL=postgresql://sbl:***@postgres:5432/sbl?serverVersion=16
```

Ce filtrage couvre les formes connues, pas l'inattendu — et ces valeurs venant du `.env` du serveur plutôt que des secrets GitHub, le masquage automatique d'Actions ne s'y applique pas. Les logs ne sont donc publiés que sur `workflow_dispatch`, c'est-à-dire quand quelqu'un les déclenche pour les lire. Un déploiement automatique qui échoue nomme la boucle de crash via l'étape d'attente, sans rien publier.

## Vérification

Logique de la boucle d'attente testée hors CI sur cinq scénarios (sain / boucle de crash / `exited` / conteneur absent / jamais stable) — codes de sortie conformes. Filtrage des secrets testé sur les formes `KEY=v`, `KEY: v`, `KEY = v`, URI avec et sans utilisateur ; les URL sans identifiants sont laissées intactes. YAML validé.

## Ensuite

Une fois cette PR fusionnée, un `workflow_dispatch` du CD affichera la raison du crash, et on pourra corriger la panne elle-même.
