### PR TITLE
fix(docker): embarquer .env dans l'image, sans quoi l'API ne démarre pas

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,12 @@ Dockerfile
 docker-compose*.yml
 
 # Development
-.env
+# `.env` n'est PAS exclu : Symfony exige sa présence au démarrage
+# (Dotenv::bootEnv), même quand toute la configuration vient de vraies
+# variables d'environnement. Il ne contient que des valeurs par défaut, jamais
+# de secrets — ceux-ci vivent dans `.env.local`, exclu ci-dessous, et sont
+# fournis en production par le docker-compose (les vraies variables
+# d'environnement l'emportent sur le fichier).
 .env.local
 .env.*.local
 var/


### PR DESCRIPTION
## Symptôme

Le conteneur `sbl-api` **plante au démarrage et redémarre en boucle** depuis le 23/07. Conséquence : le CD n'a jamais abouti (7 exécutions, 7 échecs) — `docker compose exec` tombe sur un conteneur en redémarrage et se fait tuer, d'où le `exit code 137` sans explication.

L'étape de diagnostic ajoutée en #72 a livré les logs du conteneur :

```
[SBL] Attente de PostgreSQL...
[SBL] PostgreSQL disponible!
[SBL] Exécution des migrations Doctrine...

Fatal error: Uncaught Symfony\Component\Dotenv\Exception\PathException:
Unable to read the "/var/www/html/.env" environment file.
  #2 SymfonyRuntime.php(118): Dotenv->bootEnv('/var/www/html/...', 'dev', ...)
  #4 /var/www/html/bin/console(15)
```

En boucle, à l'identique.

## Enchaînement

1. `.dockerignore` excluait `.env`, au milieu du bloc « # Development ».
2. Le `COPY . .` du Dockerfile ne l'embarquait donc jamais → pas de `/var/www/html/.env` dans l'image.
3. L'entrypoint lance `lexik:jwt:generate-keypair` puis `doctrine:migrations:migrate`.
4. `bin/console` boote `SymfonyRuntime` → `Dotenv::bootEnv()`, qui **exige la présence de `.env`** même quand toute la configuration vient de vraies variables d'environnement. Absent → exception fatale.
5. L'entrypoint meurt, `restart: unless-stopped` relance, retour au point 3.

Les variables du docker-compose (`APP_ENV: prod`, `DATABASE_URL`…) n'y changent rien : Symfony réclame le fichier avant de les lire.

## Correctif

```diff
 # Development
-.env
 .env.local
 .env.*.local
```

`.env` est fait pour être versionné. Relu ligne à ligne : il ne contient que des valeurs par défaut — `APP_SECRET=CHANGE_ME_dev_only_secret`, `DATABASE_URL` pointant sur `127.0.0.1`, `DISCORD_CLIENT_SECRET=your_discord_client_secret` — et porte lui-même l'avertissement « DO NOT DEFINE PRODUCTION SECRETS IN THIS FILE ».

`.env.local` et `.env.*.local` **restent exclus** : ce sont eux qui portent les secrets. En production, les valeurs réelles viennent du docker-compose, et les vraies variables d'environnement l'emportent sur le fichier.

### Alternative écartée

`composer dump-env prod` au build génère `.env.local.php` et fait sauter la lecture de `.env`. Plus idiomatique en principe, mais inapplicable ici : les variables ne sont pas disponibles au moment du build, elles arrivent par le compose au runtime.

## Vérification

Le job « Build image Docker » de cette PR construit l'image avec le nouveau contexte. La validation de bout en bout se fera par un `workflow_dispatch` du CD après fusion : si le conteneur tient debout, l'étape d'attente passe et les migrations s'exécutent — une première.

## À traiter séparément

- `.env` fixe `APP_ENV=dev`. Sans danger tant que le compose impose `prod` en vraie variable, mais l'image lancée hors compose démarrerait en dev.
- L'entrypoint joue déjà les migrations au démarrage ; l'étape `Run Doctrine migrations` du CD refait le travail. Inoffensif, redondant.
