### PR TITLE
fix(cd): prendre le verrou de déploiement partagé avant docker compose

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,12 +55,37 @@ jobs:
             -e "ssh -i ~/.ssh/deploy_key -p $SSH_PORT" \
             ./ "$SSH_TARGET:$DEPLOY_PATH/api/"
 
+      # Quatre dépôts pilotent le même projet docker compose sur le même
+      # serveur. La clé `concurrency:` ci-dessus ne protège que de ce dépôt :
+      # ses groupes sont propres à un dépôt et ne se voient pas entre eux. Les
+      # étapes qui modifient l'état Docker prennent donc un verrou côté
+      # serveur, partagé avec `infrastructure`, `bot` et `SBL-app`.
+      #
+      # Chaque étape est une session SSH distincte, et le verrou tombe avec
+      # elle : un autre déploiement peut encore s'intercaler *entre* deux
+      # étapes. La fenêtre passe de « toute la durée du déploiement » à
+      # « l'intervalle entre deux étapes », sans disparaître complètement.
       - name: Rebuild service
         run: |
           set -euo pipefail
           ssh -i ~/.ssh/deploy_key -p "$SSH_PORT" "$SSH_TARGET" \
-            "cd '$DEPLOY_PATH' && docker compose up -d --build api api-nginx"
+            "DEPLOY_PATH='$DEPLOY_PATH' bash -s" <<'REMOTE'
+          set -euo pipefail
 
+          exec 9>/tmp/sbl-deploy.lock
+          if ! flock -w 300 9; then
+            echo "::error::verrou de déploiement non obtenu après 300 s : un autre déploiement est en cours"
+            exit 1
+          fi
+
+          cd "$DEPLOY_PATH"
+          docker compose up -d --build api api-nginx
+          REMOTE
+
+      # Étape en lecture seule (`docker inspect`), volontairement hors verrou :
+      # le tenir ici bloquerait les autres déploiements jusqu'à 60 s sans rien
+      # protéger.
+      #
       # `docker compose up -d` rend la main dès que le conteneur est lancé, pas
       # quand il est viable. On vérifie qu'il tient debout avant d'aller plus
       # loin : `up --build` venant de recréer le conteneur, tout redémarrage
@@ -118,13 +143,35 @@ jobs:
         run: |
           set -euo pipefail
           ssh -i ~/.ssh/deploy_key -p "$SSH_PORT" "$SSH_TARGET" \
-            "cd '$DEPLOY_PATH' && docker compose exec -T api php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration"
+            "DEPLOY_PATH='$DEPLOY_PATH' bash -s" <<'REMOTE'
+          set -euo pipefail
+
+          exec 9>/tmp/sbl-deploy.lock
+          if ! flock -w 300 9; then
+            echo "::error::verrou de déploiement non obtenu après 300 s : un autre déploiement est en cours"
+            exit 1
+          fi
+
+          cd "$DEPLOY_PATH"
+          docker compose exec -T api php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
+          REMOTE
 
       - name: Prune dangling images
         run: |
           set -euo pipefail
           ssh -i ~/.ssh/deploy_key -p "$SSH_PORT" "$SSH_TARGET" \
-            "cd '$DEPLOY_PATH' && docker image prune -f"
+            "DEPLOY_PATH='$DEPLOY_PATH' bash -s" <<'REMOTE'
+          set -euo pipefail
+
+          exec 9>/tmp/sbl-deploy.lock
+          if ! flock -w 300 9; then
+            echo "::error::verrou de déploiement non obtenu après 300 s : un autre déploiement est en cours"
+            exit 1
+          fi
+
+          cd "$DEPLOY_PATH"
+          docker image prune -f
+          REMOTE
 
       # Sans ça, un plantage du conteneur n'est lisible qu'en se connectant au
       # serveur.


### PR DESCRIPTION
## Contexte

Quatre dépôts — `infrastructure`, `api`, `bot`, `SBL-app` — pilotent **le même projet docker compose sur le même serveur**. Un `up` concurrent recrée des conteneurs sous les pieds de l'autre, `--remove-orphans` peut supprimer un service que l'autre vient de lancer, et `image prune -f` peut emporter les couches intermédiaires d'un build en cours.

**`concurrency:` ne protège de rien ici** : les groupes de concurrence sont propres à un dépôt. Quatre dépôts déclarant le même nom de groupe ne se voient pas et démarrent simultanément.

Le seul point commun aux quatre pipelines étant le serveur lui-même, les commandes compose passent sous un `flock` sur `/tmp/sbl-deploy.lock` :

```bash
exec 9>/tmp/sbl-deploy.lock
if ! flock -w 300 9; then
  echo "::error::verrou de déploiement non obtenu après 300 s : un autre déploiement est en cours"
  exit 1
fi
```

Le verrou est libéré à la fermeture de la session SSH, y compris si le job est annulé.

Le verrou est déjà posé côté `infrastructure` (SBL-app/infrastructure#11, fusionnée). Cette PR fait partie des trois qui le rendent effectif — il est inerte tant que les quatre dépôts ne le prennent pas.

## Origine

Le 19/08, les quatre PR Bloc 4 fusionnées dans la même minute ont cassé le déploiement : le `rsync --delete` d'`infrastructure` a effacé les sources des trois autres pendant leurs builds. Ce dégât-là est corrigé par des exclusions dans #11. Le verrou traite le second effet du partage : la concurrence sur le projet compose.

## Prérequis

Le verrou suppose que les quatre dépôts se connectent avec **le même utilisateur SSH** — sinon `/tmp/sbl-deploy.lock` appartient à l'un et reste inaccessible aux autres. C'est le cas si `SSH_USER` porte la même valeur dans les quatre jeux de secrets. Je ne peux pas le vérifier, les secrets sont masqués.

## Vérification

`flock` testé localement sur trois scénarios : verrou libre (obtenu), verrou tenu au-delà du délai (échec propre avec l'annotation `::error::`), verrou tenu puis relâché dans le délai (obtenu après attente). YAML validé et syntaxe bash de chaque bloc distant vérifiée.

## Spécificité de ce dépôt : une fenêtre subsiste

Contrairement à `bot` et `SBL-app`, dont le déploiement tient en une seule commande, celui-ci est découpé en quatre étapes depuis #72. Trois modifient l'état Docker et prennent le verrou :

| Étape | Verrou |
|---|---|
| `Rebuild service` | ✅ |
| `Wait for the api container to stabilise` | ❌ volontairement |
| `Run Doctrine migrations` | ✅ |
| `Prune dangling images` | ✅ |

L'étape d'attente ne fait que des `docker inspect` : tenir le verrou pendant qu'elle sonde le conteneur bloquerait les autres déploiements jusqu'à 60 s sans rien protéger.

**Chaque étape est une session SSH distincte, et le verrou tombe avec elle.** Un autre déploiement peut donc encore s'intercaler *entre* deux étapes. La fenêtre passe de « toute la durée du déploiement » à « l'intervalle entre deux étapes » — elle rétrécit beaucoup, elle ne disparaît pas.

La supprimer demanderait de refusionner les quatre étapes en une seule session SSH, ce qui annulerait la lisibilité des échecs apportée par #72 — c'est précisément ce découpage qui a permis d'identifier la boucle de crash corrigée en #73. Le compromis me semble du bon côté, mais dis-moi si tu préfères l'inverse.
