### PR TITLE
ci(cd): vérifier que l'API sert avant de déclarer le déploiement réussi

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,6 +14,9 @@ name: CD
 #
 # Secrets requis :
 #   SSH_HOST, SSH_USER, SSH_KEY, SSH_PORT (optionnel, défaut 22), DEPLOY_PATH
+#   API_HEALTH_URL (optionnel) : URL publique de /api/health, vérifiée après
+#     déploiement. Passe par un secret pour ne pas publier le domaine dans ce
+#     dépôt public ; non défini, le test de fumée est ignoré.
 
 on:
   push:
@@ -172,6 +175,45 @@ jobs:
           cd "$DEPLOY_PATH"
           docker image prune -f
           REMOTE
+
+      # Un `docker compose up` réussi ne prouve pas que l'application sert
+      # quelque chose. Le 2026-08-20, ce workflow était vert — conteneur
+      # stable, migrations passées — alors que tous les endpoints renvoyaient
+      # 500, y compris les routes inexistantes. Un déploiement qui se déclare
+      # réussi pendant que l'API est hors service est pire qu'un déploiement
+      # qui échoue : personne ne va voir.
+      #
+      # Seul 200 est accepté : `/api/health` renvoie 503 quand une sonde
+      # critique tombe, ce qui est un échec de déploiement, pas un succès.
+      - name: Smoke test the health endpoint
+        env:
+          API_HEALTH_URL: ${{ secrets.API_HEALTH_URL }}
+        run: |
+          set -uo pipefail
+
+          if [ -z "${API_HEALTH_URL:-}" ]; then
+            echo "::warning::secret API_HEALTH_URL non défini — test de fumée ignoré"
+            exit 0
+          fi
+
+          code=000
+          for attempt in $(seq 1 6); do
+            # `curl -w` écrit déjà 000 quand il échoue ; l'assignation de
+            # repli ne doit pas s'y ajouter, d'où `|| code=000` et non `|| echo`.
+            code=$(curl -sS -o /tmp/health.json -w '%{http_code}' --max-time 15 "$API_HEALTH_URL") || code=000
+            if [ "$code" = "200" ]; then
+              echo "/api/health répond HTTP 200"
+              head -c 2000 /tmp/health.json
+              exit 0
+            fi
+            echo "tentative $attempt/6 : HTTP $code"
+            sleep 5
+          done
+
+          echo "::error::l'API ne sert pas : /api/health répond HTTP $code après 6 tentatives"
+          echo '--- réponse ---'
+          head -c 2000 /tmp/health.json || true
+          exit 1
 
       # Sans ça, un plantage du conteneur n'est lisible qu'en se connectant au
       # serveur.


### PR DESCRIPTION
## Le défaut

Ce workflow est vert depuis ce matin. L'API renvoie **500 sur tout** :

| URL | Réponse |
|---|---|
| `/api/health` | 500 |
| `/api/seasons`, `/api/teams`, `/api/divisions` | 500 |
| `/api/nexistepas` | 500 — devrait être 404 |
| `/` | 500 |

Pendant ce temps, le CD rapporte : conteneur stable, migrations passées (`[OK] Already at the latest version`), toutes les étapes au succès. **Rien dans le pipeline ne signale que l'application est hors service.**

Un `docker compose up` réussi prouve qu'un conteneur tourne, pas qu'il sert quelque chose. Et un déploiement qui se déclare réussi pendant que l'API est morte est pire qu'un déploiement qui échoue : personne ne va voir.

## Correctif

Une étape finale interroge `/api/health` : jusqu'à six tentatives à cinq secondes d'intervalle, pour laisser au conteneur le temps de chauffer.

**Seul 200 est accepté.** L'endpoint renvoie 503 quand une sonde critique tombe (PostgreSQL injoignable, migrations en retard) — c'est un échec de déploiement, pas un succès dégradé.

En cas d'échec sur un `workflow_dispatch`, l'étape `Collect container diagnostics` ajoutée en #72 publie dans la foulée les logs du conteneur. Le pipeline devient capable de dire *que* l'API est cassée **et** *pourquoi*, sans SSH.

## ⚠️ Un secret à créer, sinon l'étape ne fait rien

L'URL vient du secret **`API_HEALTH_URL`**, pour ne pas publier le domaine de production dans ce dépôt public — `.env.example` s'en tient d'ailleurs à des placeholders.

Tant que le secret n'est pas défini, l'étape émet un avertissement et passe :

```
::warning::secret API_HEALTH_URL non défini — test de fumée ignoré
```

Une absence de configuration ne doit pas faire échouer un déploiement par ailleurs sain — mais **cette PR ne protège de rien tant que le secret n'existe pas**. À créer dans Settings → Secrets and variables → Actions, avec l'URL complète de `/api/health`.

## Vérification

Les quatre chemins ont été exercés hors CI, dont deux contre le vrai serveur :

| Cas | Résultat |
|---|---|
| Secret absent | avertissement, `exit 0` |
| Réponse 200 | succès, corps affiché |
| **API réelle (500)** | `::error::l'API ne sert pas : /api/health répond HTTP 500 après 6 tentatives`, `exit 1` |
| Hôte injoignable | `HTTP 000`, échec propre |

Le cas 3 tourne contre la production telle qu'elle est en ce moment : l'étape attrape exactement la panne qu'elle est censée attraper.

Un défaut relevé au passage pendant ces tests : `curl -w '%{http_code}'` écrit déjà `000` quand il échoue, et le repli `|| echo 000` s'y ajoutait — le log affichait `HTTP 000000`. Corrigé en `|| code=000`.

## Ce que ça ne fait pas

Ça ne répare pas les 500. La cause reste à identifier — il faut les logs du conteneur, que cette PR rend justement accessibles au prochain déploiement manuel.
