### PR TITLE
ci(cd): publier aussi les fichiers de log Monolog dans le diagnostic

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -230,15 +230,35 @@ jobs:
         run: |
           set -uo pipefail
           ssh -i ~/.ssh/deploy_key -p "$SSH_PORT" "$SSH_TARGET" \
-            "cd '$DEPLOY_PATH' \
-              && echo '--- docker compose ps ---' \
-              && docker compose ps \
-              && echo '--- docker compose logs api (100 dernières lignes) ---' \
-              && docker compose logs --tail=100 --no-color api" 2>&1 \
+            "DEPLOY_PATH='$DEPLOY_PATH' bash -s" 2>&1 <<'REMOTE' \
             | sed -E \
                 -e 's#(://[^:/@[:space:]]*):[^@[:space:]]+@#\1:***@#g' \
                 -e 's#((APP_SECRET|APP_PASSWORD|JWT_PASSPHRASE|POSTGRES_PASSWORD|DISCORD_CLIENT_SECRET|DISCORD_BOT_SECRET|MAILER_DSN)[[:space:]]*[=:][[:space:]]*)[^[:space:]]+#\1***#gi' \
             || true
+          set -uo pipefail
+          cd "$DEPLOY_PATH"
+
+          echo '--- docker compose ps ---'
+          docker compose ps || true
+
+          echo '--- docker compose logs api (100 dernières lignes) ---'
+          docker compose logs --tail=100 --no-color api || true
+
+          # Les erreurs ne passent pas par stdout : en prod, Monolog écrit dans
+          # des `rotating_file` (`var/log/error-2026-08-20.log`). Sans ça, le
+          # diagnostic ne montre que des « GET /index.php 500 » sans cause.
+          echo '--- var/log : fichiers Monolog les plus récents ---'
+          docker compose exec -T api sh -c '
+            cd var/log 2>/dev/null || { echo "(pas de répertoire var/log)"; exit 0; }
+            found=""
+            for f in $(ls -t error-*.log prod-*.log 2>/dev/null | head -2); do
+              found=1
+              echo "--- $f (60 dernières lignes) ---"
+              tail -n 60 "$f"
+            done
+            [ -n "$found" ] || echo "(aucun fichier de log trouvé)"
+          ' || true
+          REMOTE
 
       - name: Clean up SSH key
         if: always()


### PR DESCRIPTION
## Le défaut

L'étape de diagnostic ajoutée en #72 ne lit que la sortie standard du conteneur. Or en production, `config/packages/monolog.yaml` n'y envoie **que les dépréciations** :

```yaml
main:        { type: rotating_file, path: "%kernel.logs_dir%/%kernel.environment%.log" }
error:       { type: rotating_file, path: "%kernel.logs_dir%/error.log", level: error }
deprecation: { type: stream, path: php://stderr }
```

Les erreurs partent dans des fichiers, à l'intérieur du conteneur. L'étape regardait donc systématiquement au mauvais endroit.

Concrètement, sur le déploiement de ce matin où l'API renvoyait 500 sur tous les endpoints, le diagnostic n'a ramené que ça :

```
[SBL] Migrations terminées.
[20-Aug-2026 09:43:54] NOTICE: fpm is running, pid 1
[20-Aug-2026 09:43:54] NOTICE: ready to handle connections
172.20.0.4 - "GET /index.php" 500
172.20.0.4 - "GET /index.php" 500
172.20.0.4 - "GET /index.php" 500
```

Six requêtes en échec, **aucune exception, aucune cause**. L'étape voyait le symptôme sans jamais pouvoir atteindre l'explication — exactement ce qu'elle était censée éviter.

## Correctif

Les deux fichiers de log les plus récents sont publiés en plus des logs de conteneur.

Monolog suffixe ses fichiers par la date (`error-2026-08-20.log`) : ils sont donc sélectionnés par ordre de modification, pas par un nom fixe. Un `tail var/log/error.log` n'aurait rien trouvé.

Les cas dégradés sont signalés sans faire échouer l'étape :

| Situation | Sortie |
|---|---|
| Fichiers présents | les 2 plus récents, 60 lignes chacun |
| `var/log` vide | `(aucun fichier de log trouvé)` |
| `var/log` absent | `(pas de répertoire var/log)` |

## Confidentialité

Le filtrage des identifiants s'applique à cette sortie comme au reste — vérifié : un `DATABASE_URL=postgresql://sbl:motdepasse@…` présent dans une trace d'exception ressort masqué.

Ces fichiers sont plus bavards que les logs de conteneur, donc l'exposition est réelle. Deux garde-fous inchangés : le filtrage, et le fait que l'étape ne s'exécute que sur `workflow_dispatch`, jamais sur un déploiement automatique. La limite reste la même — un secret loggué sous une forme inattendue passerait à travers.

## Vérification

Le script distant a été exercé hors CI avec un `docker` simulé : sélection correcte des deux fichiers les plus récents (l'antérieur ignoré), masquage effectif du mot de passe dans la trace, et les deux cas dégradés ci-dessus. La sémantique du heredoc placé avant le pipe — subtile — a été vérifiée séparément plutôt que supposée. YAML validé.

## Ensuite

Une fois fusionnée, un `workflow_dispatch` du CD donnera enfin la cause des 500.
