### PR TITLE
fix(docker): rendre var/ à www-data avant de démarrer PHP-FPM

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,5 +20,17 @@ echo "[SBL] Exécution des migrations Doctrine..."
 php bin/console doctrine:migrations:migrate --no-interaction
 echo "[SBL] Migrations terminées."
 
+# Les commandes ci-dessus s'exécutent en root et écrivent le cache Symfony :
+# `var/cache/prod` se retrouve possédé par root, alors que les workers PHP-FPM
+# tournent en www-data. Sans ce chown, la première requête échoue en écrivant
+# le cache du routeur (`rename(...): Permission denied` dans RouterListener),
+# et TOUTES les requêtes renvoient 500 — y compris les routes inexistantes, qui
+# échouent avant même d'être résolues en 404.
+#
+# Le `chown` du Dockerfile ne suffit pas : il a lieu au build, avant que root
+# ne recrée ces fichiers au démarrage du conteneur.
+echo "[SBL] Réattribution de var/ à www-data..."
+chown -R www-data:www-data var
+
 echo "[SBL] Démarrage de PHP-FPM..."
 exec php-fpm


### PR DESCRIPTION
## Symptôme

L'API renvoie **500 sur tous les endpoints** — `/api/health`, `/api/seasons`, `/api/teams`, la racine, et jusqu'aux routes inexistantes, qui auraient dû répondre 404.

Le conteneur tourne pourtant, les migrations passent, PHP-FPM démarre proprement. `docker compose logs api` ne montrait que ça :

```
[20-Aug-2026 10:00:53] NOTICE: ready to handle connections
172.20.0.4 - "GET /index.php" 500
172.20.0.4 - "GET /index.php" 500
```

## Cause

Relevée dans `var/log/error-*.log`, rendu accessible par #76 :

```
app.ERROR: Unhandled API exception
  Cannot rename "/tmp/url_matching_routes.phpeAiHNj" to
  "/var/www/html/var/cache/prod/url_matching_routes.php": Permission denied
    #6 RouterListener->onKernelRequest()

php.ERROR: file_put_contents(
  /var/www/html/var/cache/prod/monolog_dedup.log): Permission denied
```

L'enchaînement :

1. Le Dockerfile fait `chown -R www-data:www-data var` — **au build** (Dockerfile:41).
2. L'entrypoint s'exécute en **root** et lance `lexik:jwt:generate-keypair` puis `doctrine:migrations:migrate`. Ces commandes écrivent le cache Symfony, qui se retrouve **possédé par root**.
3. `exec php-fpm` démarre ses workers en **www-data**.
4. `www-data` ne peut plus écrire dans `var/cache/prod`. Le cache du routeur n'est jamais écrit, et `RouterListener` lève une exception **à chaque requête**.

Deux détails qui intriguaient trouvent ici leur explication :

- **Une route inexistante renvoyait 500 et non 404** : l'échec survient dans `RouterListener`, avant que le routage n'aboutisse. Il n'y a jamais de `NotFoundHttpException` à convertir.
- **`bin/console` fonctionnait** — migrations comprises — parce qu'il tourne en root. C'est précisément ce que le CD vérifiait, d'où un déploiement vert sur une API morte.

## Correctif

```sh
echo "[SBL] Réattribution de var/ à www-data..."
chown -R www-data:www-data var

echo "[SBL] Démarrage de PHP-FPM..."
exec php-fpm
```

Le `chown` du Dockerfile ne pouvait rien : il a lieu avant que root ne recrée ces fichiers au démarrage. Il est donc refait juste avant de passer la main à PHP-FPM.

## Vérification

Syntaxe `sh` validée. La vraie vérification sera le déploiement : le test de fumée de #75 exige un `200` sur `/api/health` et fera échouer le CD si l'API ne sert toujours pas. C'est exactement le cas qu'il a détecté ce matin.

## Piste connexe, hors périmètre

Le cache n'est pas préchauffé au build. Ajouter un `php bin/console cache:warmup` au Dockerfile éviterait que la première requête ait à le compiler — plus rapide, et une dépendance de moins à l'écriture au runtime. À traiter séparément.
