### PR TITLE
feat(health): ajouter la sonde /api/health attendue par la supervision

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -6,6 +6,13 @@
 parameters:
     # Valeur par défaut de la variable d'environnement (surchargeable via .env / conteneur).
     env(REGISTRATION_MIN_PLAYERS): '3'
+    # Version déployée, injectée au build (voir la procédure de release).
+    # Les valeurs par défaut évitent d'imposer ces variables en dev, en test et
+    # en CI, où elles n'ont pas de sens.
+    env(APP_VERSION): 'dev'
+    env(APP_COMMIT): 'unknown'
+    app.version: '%env(APP_VERSION)%'
+    app.commit: '%env(APP_COMMIT)%'
     discord.client_id: '%env(DISCORD_CLIENT_ID)%'
     discord.client_secret: '%env(DISCORD_CLIENT_SECRET)%'
     discord.redirect_uri: '%env(DISCORD_REDIRECT_URI)%'

--- a/src/Controller/HealthController.php
+++ b/src/Controller/HealthController.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Controller;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\Migrations\DependencyFactory;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Sonde de supervision consommée par Uptime Kuma et par le test de fumée du
+ * déploiement continu.
+ *
+ * Le contrat est volontairement stable : `status`, `version` et `commit` à la
+ * racine, le détail par sonde sous `checks`. Un code HTTP 503 signale qu'au
+ * moins une sonde critique est en défaut — c'est ce que la supervision
+ * interprète comme une indisponibilité.
+ *
+ * L'endpoint n'expose rien de sensible : ni DSN, ni identifiants, ni détail
+ * d'exception. Un échec de connexion remonte comme `"status": "error"` sans le
+ * message du driver, qui contient l'URL de la base.
+ */
+#[Route('/api')]
+class HealthController extends AbstractController
+{
+    public function __construct(
+        private readonly Connection $connection,
+        // Le bundle n'expose pas DependencyFactory à l'autowiring : le service
+        // doit être désigné par son identifiant.
+        #[Autowire(service: 'doctrine.migrations.dependency_factory')]
+        private readonly DependencyFactory $migrations,
+        #[Autowire('%app.version%')]
+        private readonly string $version,
+        #[Autowire('%app.commit%')]
+        private readonly string $commit,
+    ) {
+    }
+
+    // `app_health` est déjà pris par TestController::health(), une sonde
+    // superficielle exposée sur /health. Celle-ci ne la remplace pas d'office :
+    // la retirer est une décision à part, quelque chose peut la surveiller.
+    #[Route('/health', name: 'app_api_health', methods: ['GET'])]
+    public function health(): JsonResponse
+    {
+        $checks = [
+            'database' => $this->checkDatabase(),
+            'migrations' => $this->checkMigrations(),
+        ];
+
+        // Le code HTTP traduit la disponibilité, le champ `status` la santé.
+        // Une base injoignable rend l'API inutilisable : 503. Des migrations en
+        // attente signalent une dérive de schéma, réelle mais non bloquante —
+        // et un 503 sur ce motif ferait osciller la supervision pendant un
+        // déploiement. L'état est donc « degraded » avec un 200, et une sonde
+        // Uptime Kuma peut alerter dessus en cherchant le mot-clé
+        // `"status":"ok"` dans le corps de la réponse.
+        $available = Response::HTTP_OK === $checks['database']['status_code'];
+        $degraded = false;
+        foreach ($checks as $check) {
+            if ('ok' !== $check['status']) {
+                $degraded = true;
+            }
+        }
+
+        foreach ($checks as $name => $check) {
+            unset($checks[$name]['status_code']);
+        }
+
+        $status = 'ok';
+        if (!$available) {
+            $status = 'error';
+        } elseif ($degraded) {
+            $status = 'degraded';
+        }
+
+        return new JsonResponse(
+            [
+                'status' => $status,
+                'version' => $this->version,
+                'commit' => $this->commit,
+                'timestamp' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
+                'checks' => $checks,
+            ],
+            $available ? Response::HTTP_OK : Response::HTTP_SERVICE_UNAVAILABLE
+        );
+    }
+
+    /**
+     * Connectivité PostgreSQL et latence de l'aller-retour.
+     */
+    private function checkDatabase(): array
+    {
+        $start = microtime(true);
+
+        try {
+            $this->connection->executeQuery('SELECT 1');
+        } catch (\Throwable) {
+            // Le message du driver contient le DSN : on ne le propage pas.
+            return [
+                'status' => 'error',
+                'error' => 'connexion impossible',
+                'status_code' => Response::HTTP_SERVICE_UNAVAILABLE,
+            ];
+        }
+
+        return [
+            'status' => 'ok',
+            'latency_ms' => round((microtime(true) - $start) * 1000, 2),
+            'status_code' => Response::HTTP_OK,
+        ];
+    }
+
+    /**
+     * État des migrations Doctrine : une migration non appliquée signifie que
+     * le schéma ne correspond pas au code déployé.
+     */
+    private function checkMigrations(): array
+    {
+        try {
+            $this->migrations->getMetadataStorage()->ensureInitialized();
+
+            $available = $this->migrations->getMigrationPlanCalculator()->getMigrations();
+            $executed = $this->migrations->getMetadataStorage()->getExecutedMigrations();
+            $pending = $this->migrations->getMigrationStatusCalculator()->getNewMigrations();
+        } catch (\Throwable) {
+            return ['status' => 'error', 'error' => 'état des migrations indisponible'];
+        }
+
+        return [
+            'status' => 0 === count($pending) ? 'ok' : 'pending',
+            'available' => count($available),
+            'executed' => count($executed),
+            'pending' => count($pending),
+        ];
+    }
+}

--- a/tests/Functional/Controller/HealthControllerTest.php
+++ b/tests/Functional/Controller/HealthControllerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use App\Tests\Functional\ApiTestCase;
+
+/**
+ * Garde le contrat de la sonde de supervision.
+ *
+ * Uptime Kuma et le test de fumée du déploiement continu dépendent de la forme
+ * exacte de cette réponse : tout changement de clé ou de code HTTP doit casser
+ * ici avant de casser la production.
+ */
+class HealthControllerTest extends ApiTestCase
+{
+    public function testHealthIsPubliclyAccessible(): void
+    {
+        $this->client->request('GET', '/api/health');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseHeaderSame('Content-Type', 'application/json');
+    }
+
+    public function testHealthExposesTheDocumentedContract(): void
+    {
+        $this->client->request('GET', '/api/health');
+        $data = json_decode($this->client->getResponse()->getContent(), true);
+
+        foreach (['status', 'version', 'commit', 'timestamp', 'checks'] as $key) {
+            $this->assertArrayHasKey($key, $data, "La clé « $key » fait partie du contrat.");
+        }
+
+        $this->assertContains($data['status'], ['ok', 'degraded', 'error']);
+        $this->assertArrayHasKey('database', $data['checks']);
+        $this->assertArrayHasKey('migrations', $data['checks']);
+    }
+
+    public function testDatabaseCheckReportsConnectivityAndLatency(): void
+    {
+        $this->client->request('GET', '/api/health');
+        $data = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertSame('ok', $data['checks']['database']['status']);
+        $this->assertArrayHasKey('latency_ms', $data['checks']['database']);
+        $this->assertIsNumeric($data['checks']['database']['latency_ms']);
+
+        // Le DSN ne doit jamais transiter par cet endpoint public.
+        $this->assertStringNotContainsStringIgnoringCase(
+            'sqlite',
+            $this->client->getResponse()->getContent()
+        );
+    }
+
+    public function testMigrationStateIsReported(): void
+    {
+        $this->client->request('GET', '/api/health');
+        $data = json_decode($this->client->getResponse()->getContent(), true);
+
+        $migrations = $data['checks']['migrations'];
+        $this->assertContains($migrations['status'], ['ok', 'pending', 'error']);
+
+        if ('error' !== $migrations['status']) {
+            $this->assertIsInt($migrations['available']);
+            $this->assertIsInt($migrations['executed']);
+            $this->assertIsInt($migrations['pending']);
+        }
+    }
+
+    /**
+     * Une base joignable vaut disponibilité, même si le schéma a dérivé : un
+     * 503 sur des migrations en attente ferait osciller la supervision pendant
+     * un déploiement. La dégradation se lit dans `status`, pas dans le code.
+     */
+    public function testPendingMigrationsDegradeWithoutFailing(): void
+    {
+        $this->client->request('GET', '/api/health');
+        $data = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+
+        if ('ok' !== $data['checks']['migrations']['status']) {
+            $this->assertSame('degraded', $data['status']);
+        } else {
+            $this->assertSame('ok', $data['status']);
+        }
+    }
+
+    public function testVersionFallsBackWhenNotInjectedAtBuild(): void
+    {
+        $this->client->request('GET', '/api/health');
+        $data = json_decode($this->client->getResponse()->getContent(), true);
+
+        // APP_VERSION / APP_COMMIT ne sont injectés qu'au build de l'image.
+        $this->assertSame('dev', $data['version']);
+        $this->assertSame('unknown', $data['commit']);
+    }
+}


### PR DESCRIPTION
## Pourquoi

La documentation décrit `GET /api/health` comme le contrat consommé par Uptime Kuma, gardé par `HealthControllerTest`. **Cet endpoint n'existait sur aucune branche du dépôt.**

Deux conséquences, découvertes en réparant le déploiement :

- la supervision décrite dans la doc ne pouvait pas fonctionner ;
- le test de fumée ajouté en #75 visait une route absente et faisait échouer le CD alors que l'API servait correctement.

Une route `/health` existe bien, dans `TestController` — mais elle renvoie `{"status":"OK","environment":…,"php_version":…}`, sans rien savoir de la base ni des migrations.

## Ce que fait la sonde

```json
{
  "status": "degraded",
  "version": "dev",
  "commit": "unknown",
  "timestamp": "2026-08-20T10:29:04+00:00",
  "checks": {
    "database":   { "status": "ok", "latency_ms": 7.02 },
    "migrations": { "status": "pending", "available": 15, "executed": 0, "pending": 15 }
  }
}
```

### Disponibilité et santé sont deux choses

| Situation | `status` | HTTP |
|---|---|---|
| Tout au vert | `ok` | 200 |
| Migrations en attente (dérive de schéma) | `degraded` | **200** |
| PostgreSQL injoignable | `error` | **503** |

**Seule la base est traitée comme critique.** Un 503 sur des migrations en attente ferait osciller la supervision pendant un déploiement, alors que la dérive reste parfaitement visible dans `status` et `checks.migrations`.

C'est un arbitrage, pas une évidence — dis-moi s'il ne te convient pas. Pour alerter aussi sur `degraded`, il suffit de pointer Uptime Kuma sur le mot-clé `"status":"ok"` plutôt que sur le seul code HTTP.

### Confidentialité

L'endpoint est public par la règle `GET` existante de `security.yaml`. Il n'expose ni DSN, ni identifiants, ni détail d'exception : un échec de connexion remonte `"error": "connexion impossible"` sans le message du driver, **qui contient l'URL de la base**. Un test le vérifie explicitement.

### Version

`version` et `commit` viennent d'`APP_VERSION` / `APP_COMMIT`, injectés au build de l'image, avec repli sur `dev` / `unknown` partout ailleurs — dev, test et CI n'ont donc rien à configurer.

## Vérification

`HealthControllerTest` — **6 tests, 22 assertions, tous verts** : accessibilité publique, contrat de clés, connectivité et latence, absence de fuite du DSN, état des migrations, comportement dégradé, repli de version.

Le reste de l'outillage, exécuté en local :

| Contrôle | Résultat |
|---|---|
| Suite complète | 338 tests, **2 échecs dans `AuthControllerTest`** |
| PHPStan | 72 erreurs |
| PHP-CS-Fixer | propre |

Les 2 échecs et les 72 erreurs sont **identiques sur `main` sans cette PR** — je l'ai vérifié en remisant mes changements et en relançant. Ce sont des artefacts de PHP 8.5 en local ; la CI tourne en 8.3 et passe. Aucune erreur PHPStan n'est imputable aux fichiers ajoutés.

## Choix de portée

- **`TestController::health()` est laissé en place.** Sa suppression est une décision à part : quelque chose peut surveiller `/health` aujourd'hui. D'où le nom de route `app_api_health`, `app_health` étant déjà pris.
- **La documentation n'est pas touchée ici** : elle vit dans le dépôt `infrastructure` (`docs/SUPERVISION.md`) et le `CLAUDE.md` du monorepo. Le tableau ci-dessus mérite d'y être reporté — PR séparée, autre dépôt.
- Après fusion, le secret `API_HEALTH_URL` est à repointer sur `/api/health`. Il vise `/api/seasons` depuis le contournement de ce matin.

## Relevé au passage, hors périmètre

- `.php-cs-fixer.cache` n'est pas dans `.gitignore` — il s'est glissé dans mon `git add -A`, je l'ai retiré avant de committer.
- `TestController::index()` énumère publiquement **toutes** les routes GET de l'API sur `/`. C'est une surface d'information gratuite pour qui cherche des endpoints.
